### PR TITLE
feat: allow editing exams

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,11 +12,15 @@
     <h1>Provas</h1>
 
     <div class="card">
-      <h2>Criar nova prova</h2>
+      <h2>Nova / Editar prova</h2>
       <form id="examForm">
+        <input type="hidden" id="examId" />
         <label>Título <input id="title" required /></label>
         <label>Descrição <textarea id="description"></textarea></label>
-        <button type="submit">Salvar</button>
+        <div class="row">
+          <button type="submit" id="saveExam">Salvar</button>
+          <button type="button" id="cancelEdit" class="secondary">Cancelar edição</button>
+        </div>
       </form>
     </div>
 

--- a/public/index.js
+++ b/public/index.js
@@ -1,5 +1,32 @@
 const api = (u, o={}) => fetch(u, o).then(r => r.json());
 
+let editingId = null;
+const titleInput = document.getElementById('title');
+const descInput = document.getElementById('description');
+const saveBtn = document.getElementById('saveExam');
+const cancelBtn = document.getElementById('cancelEdit');
+
+function resetForm(){
+  editingId = null;
+  document.getElementById('examId').value = '';
+  titleInput.value = '';
+  descInput.value = '';
+  saveBtn.textContent = 'Salvar';
+  cancelBtn.style.display = 'none';
+}
+
+function startEdit(exam){
+  editingId = exam._id;
+  document.getElementById('examId').value = exam._id;
+  titleInput.value = exam.title;
+  descInput.value = exam.description || '';
+  saveBtn.textContent = 'Atualizar';
+  cancelBtn.style.display = 'inline-block';
+  window.scrollTo({top:0, behavior:'smooth'});
+}
+
+cancelBtn.onclick = resetForm;
+
 async function load() {
   const list = await api('/api/exams');
   const box = document.getElementById('exams');
@@ -17,11 +44,13 @@ async function load() {
         <div class="actions">
           <a href="questions.html?examId=${e._id}">Gerenciar questões</a>
           <a href="take.html?examId=${e._id}">Aplicar prova</a>
+          <button data-edit="${e._id}" class="secondary">Editar</button>
           <button data-del="${e._id}" class="secondary">Excluir</button>
         </div>
       </div>
       ${e.description ? `<p style="margin:8px 0 0">${e.description}</p>` : ''}
     `;
+    div.querySelector('[data-edit]').onclick = () => startEdit(e);
     div.querySelector('[data-del]').onclick = async () => {
       if (!confirm('Excluir a prova e suas questões?')) return;
       await api('/api/exams/' + e._id, { method: 'DELETE' });
@@ -34,17 +63,20 @@ async function load() {
 
 document.getElementById('examForm').onsubmit = async (ev) => {
   ev.preventDefault();
-  const title = document.getElementById('title').value.trim();
-  const description = document.getElementById('description').value.trim();
+  const title = titleInput.value.trim();
+  const description = descInput.value.trim();
   if (!title) { alert('Informe um título'); return; }
-  await api('/api/exams', {
-    method: 'POST',
+  const method = editingId ? 'PUT' : 'POST';
+  const url = editingId ? '/api/exams/' + editingId : '/api/exams';
+  await api(url, {
+    method,
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ title, description })
   });
-  ev.target.reset();
-  toast('Prova criada');
+  toast(editingId ? 'Prova atualizada' : 'Prova criada');
+  resetForm();
   load();
 };
 
+resetForm();
 load();


### PR DESCRIPTION
## Summary
- allow editing existing exams through main form
- add client-side logic to start, cancel and save edits

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b674b8e04832daadffb5b563af43b