### PR TITLE
Improve exam form layout and add timer controls

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -54,7 +54,7 @@ h3{font-size:16px; margin:0 0 10px;}
 
 form{display:grid; gap:14px;}
 label{display:block; color:var(--muted); font-size:14px;}
-label > input,
+label > input:not([type=checkbox]):not([type=radio]),
 label > textarea,
 label > select{
   display:block;
@@ -97,6 +97,12 @@ button.danger{background:var(--danger)}
 .row.between{justify-content:space-between;}
 .actions{display:flex; gap:12px; align-items:center;}
 ul{padding-left:18px; margin:8px 0 0;}
+
+.options{display:flex; flex-direction:column; gap:6px; margin:8px 0 0; padding:0;}
+.options .choice{display:flex; align-items:center; gap:8px; color:var(--text);}
+.options .choice > input{margin:0;}
+
+#clock{font-weight:600;}
 
 .muted{color:var(--muted); font-size:13px;}
 img.preview{max-height:72px; display:block; margin-top:8px; border-radius:10px; border:1px solid var(--border)}

--- a/public/take.html
+++ b/public/take.html
@@ -12,6 +12,12 @@
     <div class="breadcrumb">Administração &rsaquo; Aplicar Prova</div>
     <h1>Aplicar Prova</h1>
     <div id="info" class="muted"></div>
+    <div class="row actions">
+      <button type="button" id="start">Start</button>
+      <button type="button" id="pause">Pause</button>
+      <button type="button" id="stop">Stop</button>
+      <span id="clock">00:00</span>
+    </div>
     <form id="form"></form>
     <div id="result"></div>
   </div>


### PR DESCRIPTION
## Summary
- Align answer options to the left and remove list styling
- Add start, pause, stop controls with a running clock for exam timing

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689bd8538210832db1ef2927800bcc1b