### PR TITLE
Show one question at a time during exam

### DIFF
--- a/public/take.js
+++ b/public/take.js
@@ -31,50 +31,65 @@ stopBtn.onclick = () => {
 };
 
 renderClock();
+let data = null;
+let current = 0;
+const answers = [];
 
-async function load() {
-  const data = await api('/api/exams/' + examId);
-  document.getElementById('info').textContent = data.exam.title + (data.exam.description ? ' — ' + data.exam.description : '');
-  const form = document.getElementById('form'); form.innerHTML = '';
-  (data.questions || []).forEach((q, i) => {
-    const div = document.createElement('div'); div.className = 'card'; div.id = 'q'+i;
-    const opts = q.options.map((o, idx) => `
-      <label class="choice">
-        <input type="${q.type === 'multiple' ? 'checkbox':'radio'}" name="q-${q._id}" value="${idx}">
-        ${o.text ? '<span>' + o.text + '</span>' : ''}
-        ${o.imagePath ? '<img class="preview" src="${o.imagePath}"/>' : ''}
-      </label>`).join('');
-    div.innerHTML = `
-      <div><strong>Q${i+1}.</strong> ${q.text || ''} <span class="muted">[${q.type}]</span></div>
-      <div class="options">${opts}</div>
-    `;
-    form.appendChild(div);
-  });
-  const btn = document.createElement('button'); btn.textContent = 'Enviar respostas'; btn.type = 'submit';
-  form.appendChild(btn);
-
-  form.onsubmit = async (ev) => {
-    ev.preventDefault();
-    const answers = data.questions.map(q => {
-      const inputs = form.querySelectorAll('[name="q-' + q._id + '"]');
-      const arr = []; inputs.forEach(inp => { if (inp.checked) arr.push(parseInt(inp.value,10)); });
-      return { questionId: q._id, selectedIndices: arr };
-    });
-    const res = await api('/api/attempts', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ examId, answers }) });
-    show(res, data.questions);
-  };
+function saveCurrent() {
+  const q = data.questions[current];
+  const form = document.getElementById('form');
+  const inputs = form.querySelectorAll('[name="q-' + q._id + '"]');
+  const arr = [];
+  inputs.forEach(inp => { if (inp.checked) arr.push(parseInt(inp.value,10)); });
+  answers[current] = { questionId: q._id, selectedIndices: arr };
 }
 
-function show(res, questions) {
+function renderQuestion() {
+  const form = document.getElementById('form'); form.innerHTML = '';
+  const q = data.questions[current];
+  const div = document.createElement('div'); div.className = 'card'; div.id = 'q'+current;
+  const opts = q.options.map((o, idx) => `
+    <label class="choice">
+      <input type="${q.type === 'multiple' ? 'checkbox':'radio'}" name="q-${q._id}" value="${idx}">
+      ${o.text ? '<span>' + o.text + '</span>' : ''}
+      ${o.imagePath ? '<img class="preview" src="${o.imagePath}"/>' : ''}
+    </label>`).join('');
+  div.innerHTML = `
+    <div><strong>Q${current+1}.</strong> ${q.text || ''} <span class="muted">[${q.type}]</span></div>
+    <div class="options">${opts}</div>
+  `;
+  form.appendChild(div);
+
+  const btn = document.createElement('button');
+  if (current < data.questions.length - 1) {
+    btn.textContent = 'Next'; btn.type = 'button';
+    btn.onclick = () => { saveCurrent(); current++; renderQuestion(); };
+    form.onsubmit = null;
+  } else {
+    btn.textContent = 'Enviar respostas'; btn.type = 'submit';
+    form.onsubmit = async (ev) => {
+      ev.preventDefault();
+      saveCurrent();
+      const res = await api('/api/attempts', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ examId, answers }) });
+      show(res);
+    };
+  }
+  form.appendChild(btn);
+}
+
+async function load() {
+  data = await api('/api/exams/' + examId);
+  document.getElementById('info').textContent = data.exam.title + (data.exam.description ? ' — ' + data.exam.description : '');
+  current = 0;
+  answers.length = 0;
+  renderQuestion();
+}
+
+function show(res) {
   const out = document.getElementById('result');
   if (res.error) { out.innerHTML = '<div class="card">'+res.error+'</div>'; return; }
-  const { score, details } = res;
+  const { score } = res;
   out.innerHTML = '<div class="card"><strong>Resultado:</strong> ' + score.correct + '/' + score.total + ' ('+score.percent+'%)</div>';
-  details.forEach((d, i) => {
-    const div = document.getElementById('q'+i);
-    div.classList.remove('ok','bad');
-    div.classList.add(d.correct ? 'ok' : 'bad');
-  });
 }
 
 load();


### PR DESCRIPTION
## Summary
- Render only one question at a time when taking an exam.
- Added Next button to navigate through questions and gather answers sequentially.
- Submit stored answers at the end and display score summary.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689bdb211bc4832dbe7b4dad744d3125