### PR TITLE
Add PDF import for questions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "express": "^4.19.2",
     "mongoose": "^8.4.1",
     "multer": "^1.4.5-lts.1",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "pdf-parse": "^1.1.1"
   },
   "devDependencies": {
     "nodemon": "^3.0.2"

--- a/public/import.html
+++ b/public/import.html
@@ -10,11 +10,11 @@
 <body>
   <header id="app-header"></header>
   <div class="container">
-    <div class="breadcrumb">Administração &rsaquo; Importar JSON</div>
+    <div class="breadcrumb">Administração &rsaquo; Importar</div>
     <h1>Importar Provas</h1>
     <div class="card">
       <h2>Arquivo JSON</h2>
-      <form id="importForm">
+      <form id="importJsonForm">
         <label>Selecione o arquivo
           <input type="file" id="jsonFile" accept="application/json" required />
         </label>
@@ -26,6 +26,20 @@
         <pre id="sampleJson" style="overflow:auto; max-height:200px"></pre>
         <a href="sample-import.json" download class="muted">Baixar exemplo</a>
       </details>
+    </div>
+
+    <div class="card" style="margin-top:24px">
+      <h2>Arquivo PDF</h2>
+      <form id="importPdfForm">
+        <label>Título da prova
+          <input type="text" id="pdfTitle" required />
+        </label>
+        <label>Selecione o arquivo
+          <input type="file" id="pdfFile" accept="application/pdf" required />
+        </label>
+        <button type="submit">Importar PDF</button>
+      </form>
+      <div id="pdfResult" class="muted" style="margin-top:8px"></div>
     </div>
   </div>
   <script src="common.js"></script>

--- a/public/import.js
+++ b/public/import.js
@@ -1,7 +1,12 @@
-const form = document.getElementById('importForm');
+const jsonForm = document.getElementById('importJsonForm');
 const fileInput = document.getElementById('jsonFile');
 const resultBox = document.getElementById('result');
 const sampleBox = document.getElementById('sampleJson');
+
+const pdfForm = document.getElementById('importPdfForm');
+const pdfFile = document.getElementById('pdfFile');
+const pdfTitle = document.getElementById('pdfTitle');
+const pdfResult = document.getElementById('pdfResult');
 
 if (sampleBox) {
   fetch('sample-import.json')
@@ -12,7 +17,7 @@ if (sampleBox) {
     });
 }
 
-form.onsubmit = async (ev) => {
+jsonForm.onsubmit = async (ev) => {
   ev.preventDefault();
   const file = fileInput.files[0];
   if (!file) { alert('Selecione um arquivo'); return; }
@@ -35,5 +40,29 @@ form.onsubmit = async (ev) => {
   } catch (e) {
     resultBox.textContent = e.message;
     toast('Erro na importação');
+  }
+};
+
+pdfForm.onsubmit = async ev => {
+  ev.preventDefault();
+  const file = pdfFile.files[0];
+  const title = pdfTitle.value.trim();
+  if (!file || !title) { alert('Informe título e arquivo'); return; }
+  const fd = new FormData();
+  fd.append('file', file);
+  fd.append('title', title);
+  try {
+    const res = await fetch('/api/import-pdf', { method: 'POST', body: fd });
+    const json = await res.json();
+    if (res.ok) {
+      pdfResult.textContent = `Importados: ${json.imported}`;
+      toast('Importação PDF concluída');
+    } else {
+      pdfResult.textContent = json.error || 'Erro desconhecido';
+      toast('Erro na importação PDF');
+    }
+  } catch (e) {
+    pdfResult.textContent = e.message;
+    toast('Erro na importação PDF');
   }
 };


### PR DESCRIPTION
## Summary
- allow uploading PDF files to create exams
- parse PDF text into questions with options and correct answers
- add UI for importing PDF exams

## Testing
- `npm install pdf-parse@1.1.1` (fails: 403 Forbidden)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689bf3f7f900832d87d7e13e5fde9d80