### PR TITLE
feat: import questions from pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Form-data:
 - `file`: arquivo PDF com as perguntas.
 - `examId` (opcional): ID de uma prova existente para anexar as questões.
 - `title` e `description` (opcionais): usados ao criar uma nova prova se `examId` não for informado.
+- `template` (opcional): modelo de parser a ser utilizado (`default` ou `flex`).
 
 O retorno contém a quantidade de questões importadas e o `examId` utilizado.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Frontend em HTML/CSS/JS puro (tema claro/escuro), backend em **Node.js + Express
 - Upload de arquivos para questões.
 - Tema **Light/Dark** com persistência no navegador.
 - Menu de administração para fácil navegação.
+- Importação de questões a partir de arquivos **PDF**.
 
 ---
 
@@ -78,6 +79,36 @@ http://localhost:3000
 2. No menu **Administração**, cadastre suas provas.
 3. Adicione questões e alternativas (texto ou imagem).
 4. Aplique a prova para visualizar no modo de execução.
+
+---
+
+## 📥 Importação de perguntas via PDF
+
+É possível importar questões diretamente de um arquivo PDF que siga o formato:
+
+```
+NEW QUESTION 1
+Pergunta...
+A) Opção 1
+B) Opção 2
+Answer: A
+```
+
+Endpoint:
+
+```
+POST /api/import/pdf
+```
+
+Form-data:
+
+- `file`: arquivo PDF com as perguntas.
+- `examId` (opcional): ID de uma prova existente para anexar as questões.
+- `title` e `description` (opcionais): usados ao criar uma nova prova se `examId` não for informado.
+
+O retorno contém a quantidade de questões importadas e o `examId` utilizado.
+
+Também existe uma interface web em `/import-pdf.html`, acessível pelo menu **Importar PDF**, para realizar a importação pelo navegador.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "express": "^4.19.2",
     "mongoose": "^8.4.1",
     "multer": "^1.4.5-lts.1",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "pdf-parse": "^1.1.1"
   },
   "devDependencies": {
     "nodemon": "^3.0.2"

--- a/public/import-pdf.html
+++ b/public/import-pdf.html
@@ -23,6 +23,12 @@
             <option value="">-- Nova prova --</option>
           </select>
         </label>
+        <label>Modelo de parser
+          <select id="template">
+            <option value="default">Padrão</option>
+            <option value="flex">Flexível</option>
+          </select>
+        </label>
         <div id="newExam">
           <label>Título
             <input id="title" />

--- a/public/import-pdf.html
+++ b/public/import-pdf.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Importar PDF</title>
+  <script src="theme-init.js"></script>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header id="app-header"></header>
+  <div class="container">
+    <div class="breadcrumb">Administração &rsaquo; Importar PDF</div>
+    <h1>Importar PDF</h1>
+    <div class="card">
+      <h2>Arquivo PDF</h2>
+      <form id="pdfForm">
+        <label>Selecione o arquivo
+          <input type="file" id="pdfFile" accept="application/pdf" required />
+        </label>
+        <label>Prova existente
+          <select id="examSelect">
+            <option value="">-- Nova prova --</option>
+          </select>
+        </label>
+        <div id="newExam">
+          <label>Título
+            <input id="title" />
+          </label>
+          <label>Descrição
+            <textarea id="description"></textarea>
+          </label>
+        </div>
+        <button type="submit">Importar</button>
+      </form>
+      <div id="result" class="muted" style="margin-top:8px"></div>
+    </div>
+  </div>
+  <script src="common.js"></script>
+  <script src="import-pdf.js"></script>
+</body>
+</html>

--- a/public/import-pdf.js
+++ b/public/import-pdf.js
@@ -1,0 +1,65 @@
+const form = document.getElementById('pdfForm');
+const fileInput = document.getElementById('pdfFile');
+const examSelect = document.getElementById('examSelect');
+const newExamDiv = document.getElementById('newExam');
+const titleInput = document.getElementById('title');
+const descInput = document.getElementById('description');
+const resultBox = document.getElementById('result');
+
+async function loadExams() {
+  try {
+    const res = await fetch('/api/exams');
+    const exams = await res.json();
+    exams.forEach(ex => {
+      const opt = document.createElement('option');
+      opt.value = ex._id;
+      opt.textContent = ex.title;
+      examSelect.appendChild(opt);
+    });
+  } catch (e) {
+    console.error('Falha ao carregar provas', e);
+  }
+}
+
+examSelect.addEventListener('change', () => {
+  if (examSelect.value) {
+    newExamDiv.style.display = 'none';
+    titleInput.required = false;
+  } else {
+    newExamDiv.style.display = 'block';
+    titleInput.required = true;
+  }
+});
+
+loadExams();
+
+form.onsubmit = async (ev) => {
+  ev.preventDefault();
+  const file = fileInput.files[0];
+  if (!file) { alert('Selecione um arquivo'); return; }
+  try {
+    const fd = new FormData();
+    fd.append('file', file);
+    if (examSelect.value) {
+      fd.append('examId', examSelect.value);
+    } else {
+      fd.append('title', titleInput.value);
+      fd.append('description', descInput.value);
+    }
+    const res = await fetch('/api/import/pdf', {
+      method: 'POST',
+      body: fd
+    });
+    const json = await res.json();
+    if (res.ok) {
+      resultBox.textContent = `Importadas: ${json.imported}`;
+      toast('Importação concluída');
+    } else {
+      resultBox.textContent = json.error || 'Erro desconhecido';
+      toast('Erro na importação');
+    }
+  } catch (e) {
+    resultBox.textContent = e.message;
+    toast('Erro na importação');
+  }
+};

--- a/public/import-pdf.js
+++ b/public/import-pdf.js
@@ -5,6 +5,7 @@ const newExamDiv = document.getElementById('newExam');
 const titleInput = document.getElementById('title');
 const descInput = document.getElementById('description');
 const resultBox = document.getElementById('result');
+const templateSelect = document.getElementById('template');
 
 async function loadExams() {
   try {
@@ -46,6 +47,7 @@ form.onsubmit = async (ev) => {
       fd.append('title', titleInput.value);
       fd.append('description', descInput.value);
     }
+    fd.append('template', templateSelect.value);
     const res = await fetch('/api/import/pdf', {
       method: 'POST',
       body: fd

--- a/public/partials/header.html
+++ b/public/partials/header.html
@@ -5,6 +5,7 @@
       <a href="/" data-route="home">Início</a>
       <a href="/index.html" data-route="admin">Administração</a>
       <a href="/import.html" data-route="import">Importar JSON</a>
+      <a href="/import-pdf.html" data-route="import-pdf">Importar PDF</a>
     </nav>
     <div class="spacer"></div>
     <button id="theme-toggle" class="theme-toggle" title="Alternar tema">🌙 / ☀️</button>


### PR DESCRIPTION
## Summary
- add PDF import page to upload exam PDFs and send to `/api/import/pdf`
- link new page in navigation and document usage

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f1a8430c4832d982c4699b129d56a