### PR TITLE
feat: allow bulk term replacement in questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Frontend em HTML/CSS/JS puro (tema claro/escuro), backend em **Node.js + Express
 - Tema **Light/Dark** com persistência no navegador.
 - Menu de administração para fácil navegação.
 - Importação de questões a partir de arquivos **PDF**.
+- Substituição em massa de termos nos enunciados com pré-visualização.
 
 ---
 
@@ -110,6 +111,25 @@ Form-data:
 O retorno contém a quantidade de questões importadas e o `examId` utilizado.
 
 Também existe uma interface web em `/import-pdf.html`, acessível pelo menu **Importar PDF**, para realizar a importação pelo navegador.
+
+## 🔄 Substituição de termos nos enunciados
+
+Permite buscar um termo em todos os enunciados e substituí-lo em massa. É possível visualizar previamente quais questões serão afetadas e, após confirmação, aplicar as alterações.
+
+Endpoint:
+
+```
+POST /api/questions/replace
+```
+
+Body JSON:
+
+- `examId` (opcional): limita a substituição a uma prova.
+- `find`: termo a ser buscado (obrigatório).
+- `replace`: texto de substituição.
+- `confirm` (opcional): defina como `true` para aplicar; se omitido, retorna apenas o preview.
+
+A página `questions.html` possui uma seção **Substituir termos** para facilitar o uso.
 
 ---
 

--- a/public/questions.html
+++ b/public/questions.html
@@ -40,6 +40,17 @@
       </div>
       <div id="list"></div>
     </div>
+
+    <div class="card">
+      <h2>Substituir termos</h2>
+      <div class="row" style="gap:6px">
+        <input type="text" id="findTerm" placeholder="Buscar" />
+        <input type="text" id="replaceTerm" placeholder="Substituir por" />
+        <button type="button" id="previewReplace" class="secondary">Pré-visualizar</button>
+        <button type="button" id="applyReplace" class="danger" style="display:none">Confirmar</button>
+      </div>
+      <div id="replacePreview" class="muted" style="margin-top:8px"></div>
+    </div>
   </div>
   <script src="common.js"></script>
   <script src="questions.js"></script>


### PR DESCRIPTION
## Summary
- replace terms in questions with preview and confirmation
- add UI section for search/replace in question page
- document replacement endpoint and feature in README

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f2d85d610832d9765ca1b2bd450e1