### PR TITLE
feat: add exam configuration options

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -51,6 +51,7 @@ a:hover{color:var(--accent-hover)}
 h1{font-size:34px; margin:10px 0 18px;}
 h2{font-size:20px; margin:0 0 16px;}
 h3{font-size:16px; margin:0 0 10px;}
+.exam-title{margin:20px 0;}
 
 form{display:grid; gap:14px;}
 label{display:block; color:var(--muted); font-size:14px;}
@@ -95,7 +96,7 @@ button.danger{background:var(--danger)}
 
 .row{display:flex; gap:12px; flex-wrap:wrap; align-items:center;}
 .row.between{justify-content:space-between;}
-.actions{display:flex; gap:12px; align-items:center;}
+.actions{display:flex; gap:12px; align-items:center; justify-content:flex-end; margin:12px 0;}
 ul{padding-left:18px; margin:8px 0 0;}
 
 .options{display:flex; flex-direction:column; gap:6px; margin:8px 0 0; padding:0;}

--- a/public/take.html
+++ b/public/take.html
@@ -11,8 +11,13 @@
   <header id="app-header"></header>
   <div class="container">
     <div class="breadcrumb">Administração &rsaquo; Aplicar Prova</div>
-    <h1>Aplicar Prova</h1>
+    <h1 id="exam-title" class="exam-title"></h1>
     <div id="info" class="muted"></div>
+    <div class="card config">
+      <label><input type="checkbox" id="random"> Randomizar perguntas</label>
+      <label>Quantidade de perguntas <input type="number" id="count" min="1" /></label>
+      <label>Tempo máximo (min) <input type="number" id="maxTime" min="1" /></label>
+    </div>
     <div class="row actions">
       <button type="button" id="start">▶️ Start</button>
       <button type="button" id="pause">⏸️ Pause</button>


### PR DESCRIPTION
## Summary
- add options to randomize questions, limit count and set a maximum duration when taking an exam
- show summary of correct and incorrect answers after submission
- align control buttons to the right and highlight exam name

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fb5aa88a8832d99cdf05290dbff55