### PR TITLE
feat: add accessible exam-taking interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
     .exam-footer{position:sticky;bottom:0;height:var(--dock);display:flex;gap:12px;justify-content:flex-end;padding:12px 20px;background:var(--card);border-top:1px solid var(--border);}
     .toast{position:fixed;right:16px;bottom:16px;background:#111827;color:#fff;padding:10px 12px;border-radius:10px;opacity:0;transform:translateY(10px);transition:all .2s;}
     .toast.show{opacity:1;transform:translateY(0);}
-    .pause-overlay{position:fixed;inset:0;background:rgba(0,0,0,.5);display:none;align-items:center;justify-content:center;font-size:32px;color:#fff;z-index:40;}
+    .pause-overlay{position:fixed;left:0;right:0;top:var(--topbar);bottom:var(--dock);background:rgba(0,0,0,.5);display:none;align-items:center;justify-content:center;font-size:32px;color:#fff;z-index:40;}
     .modal{position:fixed;inset:0;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center;z-index:50;}
     .modal.hidden{display:none;}
     .modal-content{background:var(--card);padding:20px;border-radius:12px;box-shadow:0 10px 24px rgba(0,0,0,.35);display:grid;gap:12px;max-width:90%;width:400px;}
@@ -227,7 +227,9 @@
       els.pause.style.display = running ? '' : 'none';
       els.end.style.display = running ? '' : 'none';
       els.pause.textContent = state.status==='PAUSED' ? 'Resume' : 'Pause';
-      els.pauseOverlay.style.display = state.status==='PAUSED' ? 'flex' : 'none';
+      const paused = state.status==='PAUSED';
+      els.pauseOverlay.style.display = paused ? 'flex' : 'none';
+      els.pauseOverlay.setAttribute('aria-hidden', paused ? 'false' : 'true');
       const disable = state.status==='PAUSED';
       Array.from(els.form.querySelectorAll('input[name="opt"]')).forEach(inp=>inp.disabled=disable);
     }

--- a/index.html
+++ b/index.html
@@ -1,0 +1,459 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Aplicar Prova</title>
+  <style>
+    :root{
+      --topbar:70px;
+      --dock:72px;
+      --bg:#0b1220;
+      --card:#0f172a;
+      --text:#e6eaf2;
+      --border:#223154;
+      --accent:#6aa0ff;
+      --accent-hover:#88b6ff;
+      --danger:#ff6a6a;
+      --warning:#fbbf24;
+      --success:#19c37d;
+    }
+    body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,ui-sans-serif,system-ui,sans-serif;}
+    button{cursor:pointer;background:var(--accent);color:#fff;border:none;font-weight:600;padding:10px 14px;border-radius:10px;}
+    button:hover{background:var(--accent-hover);}
+    .exam-top{position:sticky;top:0;height:var(--topbar);display:flex;align-items:center;justify-content:space-between;gap:16px;padding:12px 20px;background:var(--card);border-bottom:1px solid var(--border);}
+    .exam-progress{flex:1;text-align:center;max-width:400px;}
+    .progress-bar{height:6px;background:var(--border);border-radius:4px;overflow:hidden;}
+    .progress-bar div{height:100%;width:0;background:var(--accent);transition:width .2s;}
+    .timer{font-variant-numeric:tabular-nums;padding:6px 10px;border:1px solid var(--border);border-radius:20px;}
+    .timer.warning{background:var(--warning);color:#000;}
+    .timer.danger{background:var(--danger);color:#fff;}
+    .layout{display:flex;}
+    .sidebar{width:280px;position:sticky;top:var(--topbar);height:calc(100dvh - var(--topbar));overflow:auto;padding:16px;background:var(--card);border-right:1px solid var(--border);display:flex;flex-direction:column;gap:12px;}
+    .sidebar-hidden .sidebar{display:none;}
+    .toggle-sidebar{margin-right:8px;}
+    .qnums{display:flex;flex-wrap:wrap;gap:8px;}
+    .qnum{width:40px;height:40px;border:1px solid var(--border);border-radius:8px;display:flex;align-items:center;justify-content:center;font-weight:600;cursor:pointer;background:var(--card);color:var(--text);}
+    .qnum.answered{background:var(--accent);color:#fff;}
+    .qnum.flagged{border-style:dashed;}
+    .qnum.flagged::after{content:'⚑';font-size:12px;margin-left:2px;}
+    .qnum.correct{background:var(--success);color:#fff;}
+    .qnum.wrong{background:var(--danger);color:#fff;}
+    .filters{display:flex;gap:6px;}
+    .filter{padding:6px 10px;font-size:12px;border:1px solid var(--border);background:var(--card);color:var(--text);border-radius:6px;cursor:pointer;}
+    .filter.active{background:var(--accent);color:#fff;}
+    .main-content{flex:1;padding:20px;min-height:calc(100dvh - var(--topbar) - var(--dock));display:flex;align-items:center;justify-content:center;}
+    .question-wrap{width:min(820px,92vw);margin-inline:auto;}
+    .question-card{background:var(--card);padding:24px;border-radius:12px;box-shadow:0 10px 24px rgba(0,0,0,.35);}
+    .question-card fieldset{border:none;padding:0;margin:0;}
+    .question-card legend{font-size:18px;margin-bottom:12px;}
+    .option-card{display:flex;align-items:center;gap:12px;padding:14px;border:1px solid var(--border);border-radius:10px;cursor:pointer;min-height:48px;background:var(--bg);}
+    .option-card:hover{border-color:var(--accent);}
+    .option-card input{margin:0;}
+    .option-card.correct{border-color:var(--success);}
+    .option-card.correct::after{content:'\2713';margin-left:auto;color:var(--success);}
+    .option-card.wrong{border-color:var(--danger);}
+    .option-card.wrong::after{content:'\2715';margin-left:auto;color:var(--danger);}
+    .exam-footer{position:sticky;bottom:0;height:var(--dock);display:flex;gap:12px;justify-content:flex-end;padding:12px 20px;background:var(--card);border-top:1px solid var(--border);}
+    .toast{position:fixed;right:16px;bottom:16px;background:#111827;color:#fff;padding:10px 12px;border-radius:10px;opacity:0;transform:translateY(10px);transition:all .2s;}
+    .toast.show{opacity:1;transform:translateY(0);}
+    .pause-overlay{position:fixed;inset:0;background:rgba(0,0,0,.5);display:none;align-items:center;justify-content:center;font-size:32px;color:#fff;z-index:40;}
+    .modal{position:fixed;inset:0;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center;z-index:50;}
+    .modal.hidden{display:none;}
+    .modal-content{background:var(--card);padding:20px;border-radius:12px;box-shadow:0 10px 24px rgba(0,0,0,.35);display:grid;gap:12px;max-width:90%;width:400px;}
+  </style>
+</head>
+<body>
+  <div id="settings-modal" class="modal">
+    <form id="settings-form" class="modal-content">
+      <h2>Settings</h2>
+      <label>Number of questions <input type="number" id="set-count" min="1" /></label>
+      <label><input type="checkbox" id="set-random" /> Randomize question order</label>
+      <label><input type="checkbox" id="set-shuffle" /> Shuffle options</label>
+      <label><input type="checkbox" id="set-sidebar" /> Sidebar initially hidden</label>
+      <fieldset>
+        <legend>Feedback mode</legend>
+        <label><input type="radio" name="mode" value="practice" /> Practice (immediate)</label>
+        <label><input type="radio" name="mode" value="exam" checked /> Exam (on submit)</label>
+      </fieldset>
+      <button type="submit">Begin</button>
+    </form>
+  </div>
+  <div id="shortcut-help" class="modal hidden" aria-hidden="true">
+    <div class="modal-content">
+      <h2>Shortcuts</h2>
+      <ul>
+        <li>↑/↓ navigate options</li>
+        <li>1..9 select option</li>
+        <li>M flag/unflag</li>
+        <li>N next, B back</li>
+      </ul>
+      <button type="button" id="close-help">Close</button>
+    </div>
+  </div>
+  <div id="pause-overlay" class="pause-overlay" aria-hidden="true">Paused</div>
+  <header class="exam-top">
+    <button type="button" id="toggle-sidebar" class="toggle-sidebar">☰</button>
+    <div id="exam-title" class="exam-title"></div>
+    <div class="exam-progress">
+      <div id="progress-text"></div>
+      <div class="progress-bar"><div id="progress-bar"></div></div>
+    </div>
+    <div class="exam-controls">
+      <span id="timer" role="timer" aria-live="polite" class="timer">00:00</span>
+      <button type="button" id="start">Start</button>
+      <button type="button" id="pause">Pause</button>
+      <button type="button" id="end">End</button>
+    </div>
+  </header>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="filters">
+        <button type="button" class="filter active" data-filter="all">All</button>
+        <button type="button" class="filter" data-filter="blank">Blank</button>
+        <button type="button" class="filter" data-filter="flagged">Flagged</button>
+      </div>
+      <div id="qnums" class="qnums"></div>
+    </aside>
+    <main class="main-content">
+      <div class="question-wrap">
+        <form id="question-form" class="question-card"></form>
+        <div id="result"></div>
+      </div>
+    </main>
+  </div>
+  <footer class="exam-footer">
+    <button type="button" id="back">Back</button>
+    <button type="button" id="save-next">Save &amp; Next</button>
+    <button type="button" id="mark">Mark for review</button>
+    <button type="button" id="submit">Submit</button>
+  </footer>
+  <div id="toast" class="toast" role="status" aria-live="polite">Saved just now</div>
+  <script>
+    const api = (u,o={})=>fetch(u,o).then(r=>r.json());
+    const examId = new URLSearchParams(location.search).get('examId');
+    if(!examId){ document.body.innerHTML='<p class="question-card">examId obrigatório.</p>'; throw new Error('no examId'); }
+
+    const answersKey=`answers-${examId}`;
+    const flaggedKey=`flagged-${examId}`;
+    const idxKey=`index-${examId}`;
+    const timeKey=`time-${examId}`;
+    const settingsKey=`settings-${examId}`;
+
+    const state={
+      currentIndex:0,
+      answers:{},
+      flagged:new Set(),
+      elapsedSec:0,
+      timer:null,
+      raw:null,
+      data:null,
+      settings:{},
+      mode:'exam',
+      duration:3600,
+      status:'IDLE'
+    };
+
+    const els={
+      examTitle:document.getElementById('exam-title'),
+      progressText:document.getElementById('progress-text'),
+      progressBar:document.getElementById('progress-bar'),
+      timer:document.getElementById('timer'),
+      qnums:document.getElementById('qnums'),
+      form:document.getElementById('question-form'),
+      result:document.getElementById('result'),
+      toast:document.getElementById('toast'),
+      back:document.getElementById('back'),
+      saveNext:document.getElementById('save-next'),
+      mark:document.getElementById('mark'),
+      submit:document.getElementById('submit'),
+      filters:document.querySelectorAll('.filter'),
+      start:document.getElementById('start'),
+      pause:document.getElementById('pause'),
+      end:document.getElementById('end'),
+      settingsModal:document.getElementById('settings-modal'),
+      settingsForm:document.getElementById('settings-form'),
+      setCount:document.getElementById('set-count'),
+      setRandom:document.getElementById('set-random'),
+      setShuffle:document.getElementById('set-shuffle'),
+      setSidebar:document.getElementById('set-sidebar'),
+      toggleSidebar:document.getElementById('toggle-sidebar'),
+      help:document.getElementById('shortcut-help'),
+      closeHelp:document.getElementById('close-help'),
+      pauseOverlay:document.getElementById('pause-overlay')
+    };
+
+    function updateTimer(){
+      const remaining=Math.max(0,state.duration-state.elapsedSec);
+      const m=String(Math.floor(remaining/60)).padStart(2,'0');
+      const s=String(remaining%60).padStart(2,'0');
+      els.timer.textContent=`${m}:${s}`;
+      els.timer.classList.toggle('warning',remaining<=300&&remaining>60);
+      els.timer.classList.toggle('danger',remaining<=60);
+    }
+
+    function tick(){
+      state.elapsedSec++;
+      localStorage.setItem(timeKey,state.elapsedSec);
+      updateTimer();
+      if(state.elapsedSec>=state.duration) endTimer();
+    }
+
+    function setStatus(s){ state.status=s; updateControls(); }
+
+    function startTimer(){
+      if(state.status!=='IDLE') return;
+      state.timer=setInterval(tick,1000);
+      setStatus('RUNNING');
+    }
+
+    function pauseResume(){
+      if(state.status==='RUNNING'){
+        clearInterval(state.timer); state.timer=null; setStatus('PAUSED'); localStorage.setItem(timeKey,state.elapsedSec);
+      } else if(state.status==='PAUSED'){
+        state.timer=setInterval(tick,1000); setStatus('RUNNING');
+      }
+    }
+
+    function endTimer(){
+      if(state.status==='RUNNING'||state.status==='PAUSED'){
+        clearInterval(state.timer); state.timer=null; state.elapsedSec=0; localStorage.removeItem(timeKey); updateTimer(); setStatus('ENDED');
+      }
+    }
+
+    function updateControls(){
+      els.start.style.display = state.status==='IDLE' ? '' : 'none';
+      const running = state.status==='RUNNING' || state.status==='PAUSED';
+      els.pause.style.display = running ? '' : 'none';
+      els.end.style.display = running ? '' : 'none';
+      els.pause.textContent = state.status==='PAUSED' ? 'Resume' : 'Pause';
+      els.pauseOverlay.style.display = state.status==='PAUSED' ? 'flex' : 'none';
+      const disable = state.status==='PAUSED';
+      Array.from(els.form.querySelectorAll('input[name="opt"]')).forEach(inp=>inp.disabled=disable);
+    }
+
+    function showToast(msg='Saved just now'){
+      els.toast.textContent=msg;
+      els.toast.classList.add('show');
+      setTimeout(()=>els.toast.classList.remove('show'),1500);
+    }
+
+    function buildSidebar(){
+      els.qnums.innerHTML='';
+      state.data.questions.forEach((q,idx)=>{
+        const b=document.createElement('button');
+        b.type='button'; b.className='qnum'; b.textContent=idx+1; b.dataset.index=idx;
+        b.onclick=()=>{ saveCurrent(); state.currentIndex=idx; renderQuestion(); };
+        els.qnums.appendChild(b);
+      });
+      updateSidebar();
+    }
+
+    function updateSidebar(){
+      Array.from(els.qnums.children).forEach((el,idx)=>{
+        const q=state.data.questions[idx];
+        const ansIdx=state.answers[q._id];
+        el.classList.toggle('answered',ansIdx!==undefined);
+        el.classList.toggle('flagged',state.flagged.has(q._id));
+        el.classList.toggle('current',idx===state.currentIndex);
+        if(state.mode==='practice' && ansIdx!==undefined){
+          const correct=q.options[ansIdx] && q.options[ansIdx].isCorrect;
+          el.classList.toggle('correct',correct);
+          el.classList.toggle('wrong',!correct);
+        } else {
+          el.classList.remove('correct','wrong');
+        }
+      });
+      filterQnums(document.querySelector('.filter.active').dataset.filter);
+    }
+
+    function updateProgress(){
+      const total=state.data.questions.length;
+      const answered=Object.keys(state.answers).length;
+      els.progressText.textContent=`Q${state.currentIndex+1} of ${total}`;
+      els.progressBar.style.width=(answered/total*100)+'%';
+    }
+
+    function showCorrectness(q){
+      const ans=state.answers[q._id];
+      Array.from(els.form.querySelectorAll('.option-card')).forEach((label,idx)=>{
+        const opt=q.options[idx];
+        label.classList.remove('correct','wrong');
+        if(opt.isCorrect) label.classList.add('correct');
+        if(ans===idx && !opt.isCorrect) label.classList.add('wrong');
+      });
+      let exp=els.form.querySelector('.explain');
+      if(!exp){ exp=document.createElement('div'); exp.className='explain'; els.form.appendChild(exp); }
+      exp.textContent='Explanation placeholder';
+    }
+
+    function renderQuestion(){
+      const q=state.data.questions[state.currentIndex];
+      els.form.innerHTML='';
+      const fs=document.createElement('fieldset');
+      const legend=document.createElement('legend'); legend.textContent=q.text||''; fs.appendChild(legend);
+      q.options.forEach((o,idx)=>{
+        const label=document.createElement('label'); label.className='option-card';
+        const inp=document.createElement('input'); inp.type='radio'; inp.name='opt'; inp.value=idx;
+        if(state.answers[q._id]===idx) inp.checked=true;
+        label.appendChild(inp);
+        const span=document.createElement('span'); span.textContent=o.text||''; label.appendChild(span);
+        fs.appendChild(label);
+      });
+      els.form.appendChild(fs);
+      if(state.mode==='practice' && state.answers[q._id]!==undefined) showCorrectness(q);
+      updateSidebar(); updateProgress(); updateControls();
+    }
+
+    function saveCurrent(){
+      const q=state.data.questions[state.currentIndex];
+      const checked=els.form.querySelector('input[name="opt"]:checked');
+      if(checked) state.answers[q._id]=parseInt(checked.value,10); else delete state.answers[q._id];
+      localStorage.setItem(answersKey,JSON.stringify(state.answers));
+      localStorage.setItem(idxKey,state.currentIndex);
+      updateSidebar(); updateProgress();
+      if(state.mode==='practice' && checked) showCorrectness(q);
+    }
+
+    function filterQnums(type){
+      Array.from(els.qnums.children).forEach((el,idx)=>{
+        const q=state.data.questions[idx];
+        const answered=state.answers[q._id]!==undefined;
+        const flagged=state.flagged.has(q._id);
+        let show=true;
+        if(type==='blank') show=!answered;
+        else if(type==='flagged') show=flagged;
+        el.style.display=show?'':'none';
+      });
+    }
+
+    els.filters.forEach(btn=>{
+      btn.addEventListener('click',()=>{
+        els.filters.forEach(b=>b.classList.remove('active'));
+        btn.classList.add('active');
+        filterQnums(btn.dataset.filter);
+      });
+    });
+
+    els.form.addEventListener('change',e=>{
+      if(e.target.name==='opt'){ saveCurrent(); showToast(); }
+    });
+
+    els.back.addEventListener('click',()=>{
+      saveCurrent();
+      if(state.currentIndex>0){ state.currentIndex--; localStorage.setItem(idxKey,state.currentIndex); renderQuestion(); }
+    });
+
+    els.saveNext.addEventListener('click',()=>{
+      saveCurrent();
+      if(state.currentIndex < state.data.questions.length-1){ state.currentIndex++; localStorage.setItem(idxKey,state.currentIndex); renderQuestion(); }
+    });
+
+    els.mark.addEventListener('click',()=>{
+      const q=state.data.questions[state.currentIndex];
+      if(state.flagged.has(q._id)) state.flagged.delete(q._id); else state.flagged.add(q._id);
+      localStorage.setItem(flaggedKey,JSON.stringify([...state.flagged]));
+      updateSidebar();
+    });
+
+    els.submit.addEventListener('click',async()=>{
+      saveCurrent();
+      const total=state.data.questions.length;
+      const answered=Object.keys(state.answers).length;
+      const blank=total-answered;
+      const flagged=state.flagged.size;
+      let correct=0,wrong=0;
+      if(state.mode==='practice'){
+        state.data.questions.forEach(q=>{
+          const ans=state.answers[q._id];
+          if(ans!==undefined){
+            if(q.options[ans] && q.options[ans].isCorrect) correct++; else wrong++;
+          }
+        });
+      }
+      let msg=`Submit?\nAnswered: ${answered}\nBlank: ${blank}\nFlagged: ${flagged}`;
+      if(state.mode==='practice') msg+=`\nCorrect: ${correct}\nWrong: ${wrong}`;
+      if(!confirm(msg)) return;
+      if(state.mode==='exam'){
+        const payload=Object.entries(state.answers).map(([id,idx])=>({questionId:id,selectedIndices:idx!=null?[idx]:[]}));
+        const res=await api('/api/attempts',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({examId,answers:payload})});
+        els.result.innerHTML='<div class="question-card">'+(res.error||`Score: ${res.score.correct}/${res.score.total}`)+'</div>';
+      } else {
+        els.result.innerHTML=`<div class="question-card">Score: ${correct}/${total}</div>`;
+      }
+    });
+
+    els.start.addEventListener('click',startTimer);
+    els.pause.addEventListener('click',pauseResume);
+    els.end.addEventListener('click',endTimer);
+
+    function handleKey(e){
+      if(e.target.tagName==='INPUT' || !state.data) return;
+      const opts=Array.from(els.form.querySelectorAll('input[name="opt"]'));
+      if(e.key==='ArrowDown'){ e.preventDefault(); const i=(opts.indexOf(document.activeElement)+1)%opts.length; opts[i].focus(); }
+      else if(e.key==='ArrowUp'){ e.preventDefault(); const i=(opts.indexOf(document.activeElement)-1+opts.length)%opts.length; opts[i].focus(); }
+      else if(/^[1-9]$/.test(e.key)){ const idx=parseInt(e.key,10)-1; if(opts[idx]){ opts[idx].checked=true; opts[idx].dispatchEvent(new Event('change',{bubbles:true})); }}
+      else if(e.key.toLowerCase()==='m'){ els.mark.click(); }
+      else if(e.key.toLowerCase()==='n'){ els.saveNext.click(); }
+      else if(e.key.toLowerCase()==='b'){ els.back.click(); }
+      else if(e.key==='?'){ e.preventDefault(); els.help.classList.remove('hidden'); }
+    }
+
+    document.addEventListener('keydown',handleKey);
+    els.toggleSidebar.addEventListener('click',()=>{ document.body.classList.toggle('sidebar-hidden'); });
+    els.closeHelp.addEventListener('click',()=> els.help.classList.add('hidden'));
+
+    function applySettings(){
+      state.data={exam:state.raw.exam,questions:[...state.raw.questions]};
+      if(state.settings.random) state.data.questions.sort(()=>Math.random()-0.5);
+      if(state.settings.count && state.settings.count<state.data.questions.length) state.data.questions=state.data.questions.slice(0,state.settings.count);
+      if(state.settings.shuffle) state.data.questions.forEach(q=>q.options.sort(()=>Math.random()-0.5));
+      state.answers=JSON.parse(localStorage.getItem(answersKey)||'{}');
+      state.flagged=new Set(JSON.parse(localStorage.getItem(flaggedKey)||'[]'));
+      state.currentIndex=parseInt(localStorage.getItem(idxKey)||'0',10);
+      state.elapsedSec=parseInt(localStorage.getItem(timeKey)||'0',10);
+      state.mode=state.settings.mode||'exam';
+      updateTimer();
+      buildSidebar();
+      if(state.currentIndex>=state.data.questions.length) state.currentIndex=0;
+      renderQuestion();
+    }
+
+    els.settingsForm.addEventListener('submit',e=>{
+      e.preventDefault();
+      const s={
+        count:Math.min(parseInt(els.setCount.value,10)||state.raw.questions.length,state.raw.questions.length),
+        random:els.setRandom.checked,
+        shuffle:els.setShuffle.checked,
+        hideSidebar:els.setSidebar.checked,
+        mode:els.settingsForm.mode.value
+      };
+      state.settings=s; state.mode=s.mode;
+      localStorage.setItem(settingsKey,JSON.stringify(s));
+      els.settingsModal.classList.add('hidden');
+      document.body.classList.toggle('sidebar-hidden',s.hideSidebar);
+      applySettings();
+    });
+
+    async function load(){
+      state.raw=await api('/api/exams/'+examId);
+      els.examTitle.textContent=state.raw.exam.title;
+      state.duration=state.raw.exam.duration||state.duration;
+      els.setCount.max=state.raw.questions.length;
+      els.setCount.value=state.raw.questions.length;
+      const saved=JSON.parse(localStorage.getItem(settingsKey)||'{}');
+      if(saved.count) els.setCount.value=saved.count;
+      els.setRandom.checked=!!saved.random;
+      els.setShuffle.checked=!!saved.shuffle;
+      els.setSidebar.checked=!!saved.hideSidebar;
+      if(saved.mode){ const r=els.settingsForm.querySelector(`input[name="mode"][value="${saved.mode}"]`); if(r) r.checked=true; }
+      state.settings=saved;
+      updateControls();
+    }
+
+    load();
+
+    window.addEventListener('beforeunload',e=>{ if(state.status==='RUNNING'){ e.preventDefault(); e.returnValue=''; } });
+  </script>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -7,6 +7,7 @@
   --accent:#3b82f6;
   --accent-hover:#2563eb;
   --danger:#ef4444;
+  --warning:#f59e0b;
   --success:#16a34a;
   --shadow:0 10px 24px rgba(16,24,40,.06);
   --radius:14px;
@@ -21,6 +22,7 @@
   --accent:#6aa0ff;
   --accent-hover:#88b6ff;
   --danger:#ff6a6a;
+  --warning:#fbbf24;
   --success:#19c37d;
   --shadow:0 10px 24px rgba(0,0,0,.35);
 }
@@ -159,27 +161,47 @@ img.preview{max-height:72px; display:block; margin-top:8px; border-radius:10px; 
 .progress-bar{height:6px; background:var(--border); border-radius:4px; overflow:hidden;}
 .progress-bar div{height:100%; width:0%; background:var(--accent); transition:width .2s;}
 .timer{font-variant-numeric:tabular-nums; padding:6px 10px; border-radius:20px; border:1px solid var(--border);}
+.timer.warning{background:var(--warning); color:#000;}
+.timer.danger{background:var(--danger); color:#fff;}
 .layout{display:flex; align-items:flex-start;}
 .sidebar{width:280px; position:sticky; top:70px; align-self:flex-start; padding:16px; display:flex; flex-direction:column; gap:12px;}
+.sidebar-hidden .sidebar{display:none;}
+.toggle-sidebar{margin-right:8px;}
 .qnums{display:flex; flex-wrap:wrap; gap:8px;}
 .qnum{width:40px; height:40px; border:1px solid var(--border); border-radius:8px; background:var(--card); color:var(--text); display:flex; align-items:center; justify-content:center; font-weight:600; cursor:pointer;}
 .qnum.answered{background:var(--accent); color:#fff;}
 .qnum.flagged{border-style:dashed;}
 .qnum.flagged::after{content:'⚑'; font-size:12px; margin-left:2px;}
+.qnum.correct{background:var(--success); color:#fff;}
+.qnum.wrong{background:var(--danger); color:#fff;}
 .filters{display:flex; gap:6px;}
 .filter{padding:6px 10px; font-size:12px;}
 .filter.active{background:var(--accent); color:#fff;}
-.content{flex:1; padding:20px;}
-.question-card{max-width:65ch; margin:0 auto;}
+.content{flex:1; padding:20px; display:flex; align-items:center; justify-content:center;}
+.question-card{max-width:65ch; margin:0 auto; background:var(--card); padding:24px; border-radius:var(--radius); box-shadow:var(--shadow);}
 .question-card fieldset{border:none; padding:0; margin:0;}
 .question-card legend{font-size:18px; margin-bottom:12px;}
-.option-card{display:flex; align-items:center; gap:12px; padding:14px; border:1px solid var(--border); border-radius:var(--radius); cursor:pointer;}
+.option-card{display:flex; align-items:center; gap:12px; padding:14px; border:1px solid var(--border); border-radius:var(--radius); cursor:pointer; min-height:48px; background:var(--bg);}
 .option-card:hover{border-color:var(--accent);}
 .option-card input{margin:0;}
 .option-card:focus-within{outline:3px solid var(--accent); outline-offset:2px;}
+.option-card.correct{border-color:var(--success);}
+.option-card.correct::after{content:'\2713'; margin-left:auto; color:var(--success);}
+.option-card.wrong{border-color:var(--danger);}
+.option-card.wrong::after{content:'\2715'; margin-left:auto; color:var(--danger);}
+.explain{margin-top:12px;}
 .exam-footer{position:sticky; bottom:0; z-index:20; background:var(--card); border-top:1px solid var(--border); box-shadow:var(--shadow); padding:12px 20px; display:flex; gap:12px; justify-content:flex-end;}
 @media (max-width:768px){
   .layout{flex-direction:column;}
   .sidebar{position:static; width:auto; flex-direction:row; overflow-x:auto;}
 }
 .qnum.current{outline:2px solid var(--accent);}
+.modal{position:fixed; inset:0; background:rgba(0,0,0,.6); display:flex; align-items:center; justify-content:center; z-index:50;}
+.modal.hidden{display:none;}
+.modal-content{background:var(--card); padding:20px; border-radius:var(--radius); box-shadow:var(--shadow); max-width:90%; width:400px; display:grid; gap:12px;}
+.pause-overlay{position:fixed; inset:0; background:rgba(0,0,0,.5); display:flex; align-items:center; justify-content:center; font-size:32px; color:#fff; z-index:40; opacity:0; pointer-events:none; transition:opacity .2s;}
+.paused .pause-overlay{opacity:1; pointer-events:auto;}
+.skeleton{height:150px; border-radius:var(--radius); background:linear-gradient(90deg, var(--border) 25%, var(--card) 37%, var(--border) 63%); background-size:400% 100%; animation:shimmer 1.2s infinite;}
+@keyframes shimmer{0%{background-position:100% 0}100%{background-position:-100% 0}}
+.fade{animation:fade .3s;}
+@keyframes fade{from{opacity:0; transform:translateX(10px);}to{opacity:1; transform:none;}}

--- a/public/styles.css
+++ b/public/styles.css
@@ -147,3 +147,39 @@ img.preview{max-height:72px; display:block; margin-top:8px; border-radius:10px; 
   opacity:0; transform:translateY(10px); transition:all .2s;
 }
 .toast.show{opacity:1; transform:translateY(0)}
+/* exam layout */
+.exam-top{
+  position:sticky; top:0; z-index:20;
+  display:flex; align-items:center; justify-content:space-between;
+  gap:16px; padding:12px 20px;
+  background:var(--card); border-bottom:1px solid var(--border);
+  box-shadow:var(--shadow);
+}
+.exam-progress{flex:1; text-align:center; max-width:400px;}
+.progress-bar{height:6px; background:var(--border); border-radius:4px; overflow:hidden;}
+.progress-bar div{height:100%; width:0%; background:var(--accent); transition:width .2s;}
+.timer{font-variant-numeric:tabular-nums; padding:6px 10px; border-radius:20px; border:1px solid var(--border);}
+.layout{display:flex; align-items:flex-start;}
+.sidebar{width:280px; position:sticky; top:70px; align-self:flex-start; padding:16px; display:flex; flex-direction:column; gap:12px;}
+.qnums{display:flex; flex-wrap:wrap; gap:8px;}
+.qnum{width:40px; height:40px; border:1px solid var(--border); border-radius:8px; background:var(--card); color:var(--text); display:flex; align-items:center; justify-content:center; font-weight:600; cursor:pointer;}
+.qnum.answered{background:var(--accent); color:#fff;}
+.qnum.flagged{border-style:dashed;}
+.qnum.flagged::after{content:'⚑'; font-size:12px; margin-left:2px;}
+.filters{display:flex; gap:6px;}
+.filter{padding:6px 10px; font-size:12px;}
+.filter.active{background:var(--accent); color:#fff;}
+.content{flex:1; padding:20px;}
+.question-card{max-width:65ch; margin:0 auto;}
+.question-card fieldset{border:none; padding:0; margin:0;}
+.question-card legend{font-size:18px; margin-bottom:12px;}
+.option-card{display:flex; align-items:center; gap:12px; padding:14px; border:1px solid var(--border); border-radius:var(--radius); cursor:pointer;}
+.option-card:hover{border-color:var(--accent);}
+.option-card input{margin:0;}
+.option-card:focus-within{outline:3px solid var(--accent); outline-offset:2px;}
+.exam-footer{position:sticky; bottom:0; z-index:20; background:var(--card); border-top:1px solid var(--border); box-shadow:var(--shadow); padding:12px 20px; display:flex; gap:12px; justify-content:flex-end;}
+@media (max-width:768px){
+  .layout{flex-direction:column;}
+  .sidebar{position:static; width:auto; flex-direction:row; overflow-x:auto;}
+}
+.qnum.current{outline:2px solid var(--accent);}

--- a/public/take.html
+++ b/public/take.html
@@ -8,25 +8,40 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <header id="app-header"></header>
-  <div class="container">
-    <div class="breadcrumb">Administração &rsaquo; Aplicar Prova</div>
-    <h1 id="exam-title" class="exam-title"></h1>
-    <div id="info" class="muted"></div>
-    <div class="card config">
-      <label><input type="checkbox" id="random"> Randomizar perguntas</label>
-      <label>Quantidade de perguntas <input type="number" id="count" min="1" /></label>
-      <label>Tempo máximo (min) <input type="number" id="maxTime" min="1" /></label>
+  <header class="exam-top">
+    <div id="exam-title" class="exam-title"></div>
+    <div class="exam-progress">
+      <div id="progress-text"></div>
+      <div class="progress-bar"><div id="progress-bar"></div></div>
     </div>
-    <div class="row actions">
-      <button type="button" id="start">▶️ Start</button>
-      <button type="button" id="pause">⏸️ Pause</button>
-      <button type="button" id="stop">⏹️ Stop</button>
-      <span id="clock">00:00</span>
+    <div class="exam-controls">
+      <span id="timer" role="timer" aria-live="polite" class="timer">00:00</span>
+      <button type="button" id="start">Start</button>
+      <button type="button" id="pause">Pause</button>
+      <button type="button" id="end">End</button>
     </div>
-    <form id="form"></form>
-    <div id="result"></div>
+  </header>
+  <div class="layout">
+    <aside class="sidebar">
+      <div class="filters">
+        <button type="button" class="filter active" data-filter="all">All</button>
+        <button type="button" class="filter" data-filter="blank">Blank</button>
+        <button type="button" class="filter" data-filter="flagged">Flagged</button>
+      </div>
+      <div id="qnums" class="qnums"></div>
+    </aside>
+    <main class="content">
+      <form id="question-form" class="question-card"></form>
+      <div id="result"></div>
+    </main>
   </div>
+  <footer class="exam-footer">
+    <button type="button" id="back">Back</button>
+    <button type="button" id="save-next">Save &amp; Next</button>
+    <button type="button" id="mark">Mark for review</button>
+    <button type="button" id="submit">Submit</button>
+  </footer>
+  <div id="toast" class="toast">Saved just now</div>
   <script src="common.js"></script>
   <script src="take.js"></script>
 </body>

--- a/public/take.html
+++ b/public/take.html
@@ -8,7 +8,36 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
+  <div id="settings-modal" class="modal">
+    <form id="settings-form" class="modal-content">
+      <h2>Settings</h2>
+      <label>Number of questions <input type="number" id="set-count" min="1" /></label>
+      <label><input type="checkbox" id="set-random" /> Randomize question order</label>
+      <label><input type="checkbox" id="set-shuffle" /> Shuffle options</label>
+      <label><input type="checkbox" id="set-sidebar" /> Sidebar initially hidden</label>
+      <fieldset>
+        <legend>Feedback mode</legend>
+        <label><input type="radio" name="mode" value="practice" /> Practice (immediate)</label>
+        <label><input type="radio" name="mode" value="exam" checked /> Exam (on submit)</label>
+      </fieldset>
+      <button type="submit">Begin</button>
+    </form>
+  </div>
+  <div id="shortcut-help" class="modal hidden" aria-hidden="true">
+    <div class="modal-content">
+      <h2>Shortcuts</h2>
+      <ul>
+        <li>↑/↓ navigate options</li>
+        <li>1..9 select option</li>
+        <li>M flag/unflag</li>
+        <li>N next, B back</li>
+      </ul>
+      <button type="button" id="close-help">Close</button>
+    </div>
+  </div>
+  <div id="pause-overlay" class="pause-overlay" aria-hidden="true">Paused</div>
   <header class="exam-top">
+    <button type="button" id="toggle-sidebar" class="toggle-sidebar">☰</button>
     <div id="exam-title" class="exam-title"></div>
     <div class="exam-progress">
       <div id="progress-text"></div>
@@ -41,7 +70,7 @@
     <button type="button" id="mark">Mark for review</button>
     <button type="button" id="submit">Submit</button>
   </footer>
-  <div id="toast" class="toast">Saved just now</div>
+  <div id="toast" class="toast" role="status" aria-live="polite">Saved just now</div>
   <script src="common.js"></script>
   <script src="take.js"></script>
 </body>

--- a/public/take.js
+++ b/public/take.js
@@ -295,6 +295,8 @@ els.settingsForm.addEventListener('submit', e=>{
   };
   state.settings = s;
   state.mode = s.mode;
+  els.pauseOverlay.style.display = 'none';  
+  startTimer();
   localStorage.setItem(settingsKey, JSON.stringify(s));
   els.settingsModal.classList.add('hidden');
   if(s.hideSidebar) document.body.classList.add('sidebar-hidden'); else document.body.classList.remove('sidebar-hidden');

--- a/public/take.js
+++ b/public/take.js
@@ -1,163 +1,201 @@
 const api = (u, o={}) => fetch(u, o).then(r => r.json());
 const examId = new URLSearchParams(location.search).get('examId');
-if (!examId) { document.body.querySelector('.container').insertAdjacentHTML('beforeend','<p class="card">examId obrigatório.</p>'); throw new Error('no examId'); }
-const clock = document.getElementById('clock');
-const startBtn = document.getElementById('start');
-const pauseBtn = document.getElementById('pause');
-const stopBtn = document.getElementById('stop');
-const randChk = document.getElementById('random');
-const countInput = document.getElementById('count');
-const maxTimeInput = document.getElementById('maxTime');
-const configBox = document.querySelector('.config');
-let timer = null;
-let seconds = 0;
-let remaining = null;
+if (!examId) { document.body.innerHTML = '<p class="card">examId obrigatório.</p>'; throw new Error('no examId'); }
 
-function renderClock() {
-  const sec = remaining !== null ? remaining : seconds;
-  const m = String(Math.floor(sec/60)).padStart(2,'0');
-  const s = String(sec%60).padStart(2,'0');
-  clock.textContent = m + ':' + s;
-}
-
-function startTimer() {
-  if (timer) return;
-  timer = setInterval(() => {
-    if (remaining !== null) {
-      remaining--; renderClock();
-      if (remaining <= 0) { clearInterval(timer); timer = null; autoSubmit(); }
-    } else {
-      seconds++; renderClock();
-    }
-  }, 1000);
-}
-
-startBtn.onclick = () => {
-  if (timer) return;
-  if (configBox.style.display !== 'none') applyConfig();
-  startTimer();
+const state = {
+  currentIndex: 0,
+  answers: {},
+  flagged: new Set(),
+  started: false,
+  paused: true,
+  elapsedSec: 0,
+  timer: null,
+  data: null
 };
 
-pauseBtn.onclick = () => {
-  if (!timer) return;
-  clearInterval(timer); timer = null;
+const els = {
+  examTitle: document.getElementById('exam-title'),
+  progressText: document.getElementById('progress-text'),
+  progressBar: document.getElementById('progress-bar'),
+  timer: document.getElementById('timer'),
+  qnums: document.getElementById('qnums'),
+  form: document.getElementById('question-form'),
+  result: document.getElementById('result'),
+  toast: document.getElementById('toast'),
+  back: document.getElementById('back'),
+  saveNext: document.getElementById('save-next'),
+  mark: document.getElementById('mark'),
+  submit: document.getElementById('submit'),
+  filters: document.querySelectorAll('.filter'),
+  start: document.getElementById('start'),
+  pause: document.getElementById('pause'),
+  end: document.getElementById('end')
 };
 
-stopBtn.onclick = () => {
-  if (timer) { clearInterval(timer); timer = null; }
-  seconds = 0;
-  remaining = maxTimeInput.value ? parseInt(maxTimeInput.value,10) * 60 : null;
-  renderClock();
-  configBox.style.display = '';
-};
-
-renderClock();
-let data = null;
-let current = 0;
-const answers = [];
-
-function saveCurrent() {
-  const q = data.questions[current];
-  const form = document.getElementById('form');
-  const inputs = form.querySelectorAll('[name="q-' + q._id + '"]');
-  const arr = [];
-  inputs.forEach(inp => { if (inp.checked) arr.push(parseInt(inp.value,10)); });
-  answers[current] = { questionId: q._id, selectedIndices: arr };
+function updateTimer() {
+  const m = String(Math.floor(state.elapsedSec/60)).padStart(2,'0');
+  const s = String(state.elapsedSec%60).padStart(2,'0');
+  els.timer.textContent = m+':'+s;
 }
 
-function renderQuestion() {
-  const form = document.getElementById('form'); form.innerHTML = '';
-  const q = data.questions[current];
-  const div = document.createElement('div'); div.className = 'card'; div.id = 'q'+current;
-  const opts = q.options.map((o, idx) => `
-    <label class="choice">
-      <input type="${q.type === 'multiple' ? 'checkbox':'radio'}" name="q-${q._id}" value="${idx}">
-      ${o.text ? '<span>' + o.text + '</span>' : ''}
-      ${o.imagePath ? '<img class="preview" src="${o.imagePath}"/>' : ''}
-    </label>`).join('');
-  div.innerHTML = `
-    <div><strong>Q${current+1}.</strong> ${q.text || ''} <span class="muted">[${q.type}]</span></div>
-    <div class="options">${opts}</div>
-  `;
-  form.appendChild(div);
-
-  // restore previous selections if available
-  if (answers[current]) {
-    const prev = new Set(answers[current].selectedIndices);
-    div.querySelectorAll('input').forEach(inp => {
-      if (prev.has(parseInt(inp.value, 10))) inp.checked = true;
-    });
-  }
-
-  const nav = document.createElement('div');
-  nav.className = 'row';
-
-  if (current > 0) {
-    const backBtn = document.createElement('button');
-    backBtn.type = 'button';
-    backBtn.textContent = '⬅️ Voltar';
-    backBtn.onclick = () => { saveCurrent(); current--; renderQuestion(); };
-    nav.appendChild(backBtn);
-  }
-
-  const btn = document.createElement('button');
-  if (current < data.questions.length - 1) {
-    btn.textContent = '➡️ Next'; btn.type = 'button';
-    btn.onclick = () => { saveCurrent(); current++; renderQuestion(); };
-    form.onsubmit = null;
-  } else {
-    btn.textContent = '📤 Enviar respostas'; btn.type = 'submit';
-    form.onsubmit = async (ev) => {
-      ev.preventDefault();
-      saveCurrent();
-      const res = await api('/api/attempts', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ examId, answers }) });
-      show(res);
-    };
-  }
-  nav.appendChild(btn);
-  form.appendChild(nav);
+function tick() {
+  state.elapsedSec++; updateTimer();
 }
 
-async function load() {
-  data = await api('/api/exams/' + examId);
-  document.getElementById('exam-title').textContent = data.exam.title;
-  document.getElementById('info').textContent = data.exam.description || '';
-  current = 0;
-  answers.length = 0;
+function startTimer(){
+  if (state.timer) return;
+  state.timer = setInterval(tick, 1000);
+  state.started = true; state.paused = false;
+}
+function pauseTimer(){
+  if (!state.timer) return;
+  clearInterval(state.timer); state.timer = null; state.paused = true;
+}
+function endTimer(){
+  if (state.timer) clearInterval(state.timer);
+  state.timer = null; state.started = false; state.paused = true; state.elapsedSec = 0; updateTimer();
 }
 
-function show(res) {
-  const out = document.getElementById('result');
-  if (res.error) { out.innerHTML = '<div class="card">'+res.error+'</div>'; return; }
-  const { score, details } = res;
-  const wrong = score.total - score.correct;
-  const list = details
-    .map((d, idx) => `<li>Q${idx+1}: ${d.correct ? '✅' : '❌'}</li>`)
-    .join('');
-  out.innerHTML = `<div class="card"><strong>Resultado:</strong> ${score.correct}/${score.total} (${score.percent}%)<br/>Certas: ${score.correct} | Erradas: ${wrong}<ul>${list}</ul></div>`;
+function showToast(msg='Saved just now'){
+  els.toast.textContent = msg;
+  els.toast.classList.add('show');
+  setTimeout(()=>els.toast.classList.remove('show'), 1500);
 }
 
-function applyConfig() {
-  if (randChk.checked) {
-    data.questions.sort(() => Math.random() - 0.5);
+function buildSidebar(){
+  els.qnums.innerHTML='';
+  state.data.questions.forEach((q, idx)=>{
+    const b = document.createElement('button');
+    b.type='button'; b.className='qnum'; b.textContent=idx+1; b.dataset.index=idx;
+    b.onclick=()=>{ saveCurrent(); state.currentIndex=idx; renderQuestion(); };
+    els.qnums.appendChild(b);
+  });
+  updateSidebar();
+}
+
+function updateSidebar(){
+  const total = state.data.questions.length;
+  Array.from(els.qnums.children).forEach((el, idx)=>{
+    const q = state.data.questions[idx];
+    el.classList.toggle('answered', state.answers[q._id] !== undefined);
+    el.classList.toggle('flagged', state.flagged.has(q._id));
+    el.classList.toggle('current', idx === state.currentIndex);
+  });
+  filterQnums(document.querySelector('.filter.active').dataset.filter);
+}
+
+function updateProgress(){
+  const total = state.data.questions.length;
+  const answered = Object.keys(state.answers).length;
+  els.progressText.textContent = `Q${state.currentIndex+1} of ${total}`;
+  els.progressBar.style.width = (answered/total*100)+'%';
+}
+
+function renderQuestion(){
+  const q = state.data.questions[state.currentIndex];
+  els.form.innerHTML='';
+  const fs = document.createElement('fieldset');
+  const legend = document.createElement('legend'); legend.textContent = q.text || '';
+  fs.appendChild(legend);
+  q.options.forEach((o, idx)=>{
+    const label = document.createElement('label'); label.className='option-card';
+    const inp = document.createElement('input'); inp.type='radio'; inp.name='opt'; inp.value=idx;
+    if (state.answers[q._id] === idx) inp.checked = true;
+    label.appendChild(inp);
+    const span = document.createElement('span'); span.textContent = o.text || '';
+    label.appendChild(span);
+    fs.appendChild(label);
+  });
+  els.form.appendChild(fs);
+  updateSidebar(); updateProgress();
+}
+
+function saveCurrent(){
+  const q = state.data.questions[state.currentIndex];
+  const checked = els.form.querySelector('input[name="opt"]:checked');
+  if (checked) state.answers[q._id] = parseInt(checked.value,10); else delete state.answers[q._id];
+  updateSidebar(); updateProgress();
+}
+
+function filterQnums(type){
+  Array.from(els.qnums.children).forEach((el, idx)=>{
+    const q = state.data.questions[idx];
+    const answered = state.answers[q._id] !== undefined;
+    const flagged = state.flagged.has(q._id);
+    let show = true;
+    if (type==='blank') show = !answered;
+    else if (type==='flagged') show = flagged;
+    el.style.display = show ? '' : 'none';
+  });
+}
+
+els.filters.forEach(btn=>{
+  btn.addEventListener('click', ()=>{
+    els.filters.forEach(b=>b.classList.remove('active'));
+    btn.classList.add('active');
+    filterQnums(btn.dataset.filter);
+  });
+});
+
+els.form.addEventListener('change', e=>{
+  if (e.target.name==='opt') {
+    saveCurrent();
+    showToast();
   }
-  const cnt = parseInt(countInput.value, 10);
-  if (cnt > 0) {
-    data.questions = data.questions.slice(0, cnt);
-  }
-  const max = parseInt(maxTimeInput.value, 10);
-  remaining = max > 0 ? max * 60 : null;
-  seconds = 0;
-  renderClock();
-  configBox.style.display = 'none';
-  renderQuestion();
-}
+});
 
-async function autoSubmit() {
+els.back.addEventListener('click', ()=>{
   saveCurrent();
-  const res = await api('/api/attempts', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ examId, answers }) });
-  show(res);
-  document.getElementById('form').innerHTML = '';
+  if (state.currentIndex>0){ state.currentIndex--; renderQuestion(); }
+});
+
+els.saveNext.addEventListener('click', ()=>{
+  saveCurrent();
+  if (state.currentIndex < state.data.questions.length-1){ state.currentIndex++; renderQuestion(); }
+});
+
+els.mark.addEventListener('click', ()=>{
+  const q = state.data.questions[state.currentIndex];
+  if (state.flagged.has(q._id)) state.flagged.delete(q._id); else state.flagged.add(q._id);
+  updateSidebar();
+});
+
+els.submit.addEventListener('click', async ()=>{
+  saveCurrent();
+  const total = state.data.questions.length;
+  const answered = Object.keys(state.answers).length;
+  const blank = total - answered;
+  const flagged = state.flagged.size;
+  if (!confirm(`Submit?\nAnswered: ${answered}\nBlank: ${blank}\nFlagged: ${flagged}`)) return;
+  const payload = Object.entries(state.answers).map(([id, idx])=>({questionId:id, selectedIndices: idx!=null?[idx]:[]}));
+  const res = await api('/api/attempts', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({examId, answers:payload})});
+  els.result.innerHTML = '<div class="card">'+(res.error || `Score: ${res.score.correct}/${res.score.total}`)+'</div>';
+});
+
+els.start.addEventListener('click', startTimer);
+els.pause.addEventListener('click', pauseTimer);
+els.end.addEventListener('click', endTimer);
+
+function handleKey(e){
+  if (e.target.tagName === 'INPUT') return;
+  const q = state.data.questions[state.currentIndex];
+  const opts = Array.from(els.form.querySelectorAll('input[name="opt"]'));
+  if (e.key === 'ArrowDown'){ e.preventDefault(); const i = (opts.indexOf(document.activeElement)+1)%opts.length; opts[i].focus(); }
+  else if (e.key === 'ArrowUp'){ e.preventDefault(); const i = (opts.indexOf(document.activeElement)-1+opts.length)%opts.length; opts[i].focus(); }
+  else if (/^[1-9]$/.test(e.key)){ const idx = parseInt(e.key,10)-1; if (opts[idx]) { opts[idx].checked = true; opts[idx].dispatchEvent(new Event('change',{bubbles:true})); } }
+  else if (e.key.toLowerCase()==='m'){ els.mark.click(); }
+  else if (e.key.toLowerCase()==='n'){ els.saveNext.click(); }
+  else if (e.key.toLowerCase()==='b'){ els.back.click(); }
+}
+
+document.addEventListener('keydown', handleKey);
+
+async function load(){
+  state.data = await api('/api/exams/' + examId);
+  els.examTitle.textContent = state.data.exam.title;
+  buildSidebar();
+  renderQuestion();
+  updateTimer();
 }
 
 load();


### PR DESCRIPTION
## Summary
- build sticky top bar with timer and progress indicators
- add sidebar navigation with filtering and marking for review
- implement question card layout, keyboard shortcuts, and autosave toast

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fdcbd2488832d8d39c944bdcf006f