### PR TITLE
feat: paginate question list with jQuery transitions

### DIFF
--- a/public/questions.html
+++ b/public/questions.html
@@ -25,21 +25,31 @@
         </label>
         <div id="opts"></div>
         <div class="row">
-          <button type="button" id="addOpt" class="secondary">➕ Opção</button>
+          <button type="button" id="addOpt" class="success">➕ Opção</button>
           <button type="submit">💾 Salvar questão</button>
-          <button type="button" id="cancel" class="secondary">✖️ Cancelar edição</button>
+          <button type="button" id="cancel" class="danger">✖️ Cancelar edição</button>
         </div>
       </form>
     </div>
 
-    <div class="card">
-      <h2>Questões cadastradas</h2>
-      <div class="row between">
-        <div id="qCount"></div>
-        <input type="text" id="search" placeholder="Pesquisar enunciado" />
+      <div class="card">
+        <h2>Questões cadastradas</h2>
+        <div class="row between">
+          <div id="qCount"></div>
+          <div class="row" style="gap:6px">
+            <label>Por página
+              <select id="perPage">
+                <option value="5">5</option>
+                <option value="10" selected>10</option>
+                <option value="20">20</option>
+              </select>
+            </label>
+            <input type="text" id="search" placeholder="Pesquisar enunciado" />
+          </div>
+        </div>
+        <div id="list"></div>
+        <div id="pagination" class="row" style="justify-content:center;margin-top:12px"></div>
       </div>
-      <div id="list"></div>
-    </div>
 
     <div class="card">
       <h2>Substituir termos</h2>
@@ -52,7 +62,8 @@
       <div id="replacePreview" class="muted" style="margin-top:8px"></div>
     </div>
   </div>
-  <script src="common.js"></script>
-  <script src="questions.js"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="common.js"></script>
+    <script src="questions.js"></script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -8,6 +8,7 @@
   --accent-hover:#2563eb;
   --danger:#ef4444;
   --success:#16a34a;
+  --warning:#f59e0b;
   --shadow:0 10px 24px rgba(16,24,40,.06);
   --radius:14px;
 }
@@ -22,6 +23,7 @@
   --accent-hover:#88b6ff;
   --danger:#ff6a6a;
   --success:#19c37d;
+  --warning:#fbbf24;
   --shadow:0 10px 24px rgba(0,0,0,.35);
 }
 
@@ -93,6 +95,8 @@ button:hover{background:var(--accent-hover)}
 button.secondary{background:#f3f4f6; color:#111827; border:1px solid var(--border)}
 :root[data-theme="dark"] button.secondary{background:#0b1220; color:var(--text)}
 button.danger{background:var(--danger)}
+button.success{background:var(--success)}
+button.warning{background:var(--warning)}
 
 .row{display:flex; gap:12px; flex-wrap:wrap; align-items:center;}
 .row.between{justify-content:space-between;}


### PR DESCRIPTION
## Summary
- show question totals and allow configurable pagination on the question page
- color-code action buttons and apply jQuery fade animations during page changes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689fde9b2d70832db605928b2d826e28