### PR TITLE
Adicionar formulário de prova em modal

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,9 +12,11 @@
   <div class="container">
     <h1>Provas</h1>
 
-    <div class="card">
-      <h2>Nova / Editar prova</h2>
-      <form id="examForm">
+    <button type="button" id="openExam" class="success">➕ Criar prova</button>
+
+    <div id="exam-modal" class="modal hidden">
+      <form id="examForm" class="modal-content">
+        <h2>Nova / Editar prova</h2>
         <input type="hidden" id="examId" />
         <label>Título <input id="title" required /></label>
         <label>Descrição <textarea id="description"></textarea></label>

--- a/public/index.js
+++ b/public/index.js
@@ -5,6 +5,8 @@ const titleInput = document.getElementById('title');
 const descInput = document.getElementById('description');
 const saveBtn = document.getElementById('saveExam');
 const cancelBtn = document.getElementById('cancelEdit');
+const modal = document.getElementById('exam-modal');
+const openBtn = document.getElementById('openExam');
 
 function resetForm(){
   editingId = null;
@@ -13,6 +15,7 @@ function resetForm(){
   descInput.value = '';
   saveBtn.textContent = '💾 Salvar';
   cancelBtn.style.display = 'none';
+  modal.classList.add('hidden');
 }
 
 function startEdit(exam){
@@ -22,9 +25,10 @@ function startEdit(exam){
   descInput.value = exam.description || '';
   saveBtn.textContent = '🔄 Atualizar';
   cancelBtn.style.display = 'inline-block';
-  window.scrollTo({top:0, behavior:'smooth'});
+  modal.classList.remove('hidden');
 }
 
+openBtn.onclick = () => { resetForm(); modal.classList.remove('hidden'); };
 cancelBtn.onclick = resetForm;
 
 async function load() {


### PR DESCRIPTION
## Summary
- Adiciona botão para abrir formulário de criação de prova
- Move formulário de prova para modal oculto inicialmente
- Atualiza lógica JS para controlar abertura e fechamento do modal

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a0e61c2fd8832d8da9932b0aa3a4d7