### PR TITLE
feat: support code snippet options

### DIFF
--- a/models/Question.js
+++ b/models/Question.js
@@ -2,6 +2,8 @@ const mongoose = require('mongoose');
 const OptionSchema = new mongoose.Schema({
   text: { type: String, default: '' },
   imagePath: { type: String, default: '' }, // e.g., '/uploads/xyz.png'
+  code: { type: String, default: '' },
+  language: { type: String, default: '' },
   isCorrect: { type: Boolean, default: false }
 }, { _id: false });
 

--- a/public/questions.js
+++ b/public/questions.js
@@ -117,6 +117,20 @@ function closeModal(){
 function addOptRow(data={}){
   const div=$('<div class="opt row"></div>');
   div.append(`<input class="t" placeholder="Opção" value="${data.text||''}"/>`);
+  div.append(`<textarea class="code" placeholder="Código">${data.code||''}</textarea>`);
+  const lang=$('<select class="lang"></select>').append(`
+    <option value="">Linguagem</option>
+    <option value="javascript">JavaScript</option>
+    <option value="python">Python</option>
+    <option value="java">Java</option>
+    <option value="c">C</option>
+    <option value="cpp">C++</option>
+    <option value="csharp">C#</option>
+    <option value="php">PHP</option>
+    <option value="ruby">Ruby</option>
+    <option value="go">Go</option>`);
+  lang.val(data.language||'');
+  div.append(lang);
   const file=$('<input type="file" class="f" accept="image/*" />');
   div.append(file);
   const chk=$(`<label>Correta? <input type="checkbox" class="c" ${data.isCorrect?'checked':''}/></label>`);
@@ -133,7 +147,13 @@ function addOptRow(data={}){
 function gatherForm(){
   const options=[];
   $('#opts .opt').each(function(){
-    options.push({ text:$(this).find('.t').val().trim(), imagePath:$(this).find('.f').data('imagePath')||'', isCorrect:$(this).find('.c').prop('checked') });
+    options.push({
+      text:$(this).find('.t').val().trim(),
+      code:$(this).find('.code').val(),
+      language:$(this).find('.lang').val(),
+      imagePath:$(this).find('.f').data('imagePath')||'',
+      isCorrect:$(this).find('.c').prop('checked')
+    });
   });
   return { _id:$('#qid').val(), text:$('#qtext').val().trim(), topic:$('#qtopic').val().trim(), status:$('#qstatus').val(), type:$('#qtype').val(), imagePath:$('#qimg').data('imagePath')||'', options };
 }

--- a/public/questions.js
+++ b/public/questions.js
@@ -115,9 +115,16 @@ function closeModal(){
 }
 
 function addOptRow(data={}){
+  const type = data.code ? 'code' : data.imagePath ? 'image' : 'text';
   const div=$('<div class="opt row"></div>');
-  div.append(`<input class="t" placeholder="Opção" value="${data.text||''}"/>`);
-  div.append(`<textarea class="code" placeholder="Código">${data.code||''}</textarea>`);
+  const typeSel=$('<select class="type"></select>').append(`
+    <option value="text">Descritiva</option>
+    <option value="image">Imagem</option>
+    <option value="code">Código</option>`);
+  typeSel.val(type);
+  div.append(typeSel);
+  const text=$(`<input class="t" placeholder="Opção" value="${data.text||''}"/>`);
+  const code=$(`<textarea class="code" placeholder="Código">${data.code||''}</textarea>`);
   const lang=$('<select class="lang"></select>').append(`
     <option value="">Linguagem</option>
     <option value="javascript">JavaScript</option>
@@ -130,30 +137,28 @@ function addOptRow(data={}){
     <option value="ruby">Ruby</option>
     <option value="go">Go</option>`);
   lang.val(data.language||'');
-  div.append(lang);
   const file=$('<input type="file" class="f" accept="image/*" />');
-  div.append(file);
   const chk=$(`<label>Correta? <input type="checkbox" class="c" ${data.isCorrect?'checked':''}/></label>`);
-  div.append(chk);
   const rm=$('<button type="button" class="danger">✖️</button>').on('click',()=>{div.remove();state.dirty=true;});
-  div.append(rm);
   const img=$('<img class="preview" style="display:none"/>');
-  div.append(img);
+  div.append(text).append(code).append(lang).append(file).append(chk).append(rm).append(img);
   if(data.imagePath){ img.attr('src',data.imagePath).show(); file.data('imagePath',data.imagePath); }
   file.on('change',async function(){ const f=this.files[0]; if(!f) return; const fd=new FormData(); fd.append('file',f); const res=await fetch('/api/upload',{method:'POST',body:fd}).then(r=>r.json()); if(res.path){ file.data('imagePath',res.path); img.attr('src',res.path).show(); toast('Imagem enviada'); } });
+  function update(){ const t=typeSel.val(); text.toggle(t==='text'); code.toggle(t==='code'); lang.toggle(t==='code'); file.toggle(t==='image'); img.toggle(t==='image' && !!file.data('imagePath')); }
+  typeSel.on('change',()=>{ update(); state.dirty=true; });
+  update();
   $('#opts').append(div);
 }
 
 function gatherForm(){
   const options=[];
   $('#opts .opt').each(function(){
-    options.push({
-      text:$(this).find('.t').val().trim(),
-      code:$(this).find('.code').val(),
-      language:$(this).find('.lang').val(),
-      imagePath:$(this).find('.f').data('imagePath')||'',
-      isCorrect:$(this).find('.c').prop('checked')
-    });
+    const type=$(this).find('.type').val();
+    const opt={text:'',code:'',language:'',imagePath:'',isCorrect:$(this).find('.c').prop('checked')};
+    if(type==='text') opt.text=$(this).find('.t').val().trim();
+    else if(type==='image') opt.imagePath=$(this).find('.f').data('imagePath')||'';
+    else if(type==='code'){ opt.code=$(this).find('.code').val(); opt.language=$(this).find('.lang').val(); }
+    options.push(opt);
   });
   return { _id:$('#qid').val(), text:$('#qtext').val().trim(), topic:$('#qtopic').val().trim(), status:$('#qstatus').val(), type:$('#qtype').val(), imagePath:$('#qimg').data('imagePath')||'', options };
 }

--- a/public/quiz.html
+++ b/public/quiz.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Quiz</title>
+<style>
+:root{
+  --bg:#0b1220;
+  --card:#0f172a;
+  --text:#e6eaf2;
+  --accent:#6aa0ff;
+  --accent-hover:#88b6ff;
+  --border:#223154;
+  --space-8:8px;
+  --space-12:12px;
+  --space-16:16px;
+  --space-24:24px;
+}
+*{box-sizing:border-box;}
+body{margin:0;background:var(--bg);color:var(--text);font-family:Inter,ui-sans-serif,system-ui,sans-serif;}
+button{cursor:pointer;border:none;border-radius:12px;padding:var(--space-12) var(--space-16);background:var(--accent);color:#fff;font-weight:600;}
+button:hover{background:var(--accent-hover);}
+header{display:flex;align-items:center;justify-content:space-between;padding:var(--space-16);max-width:960px;margin:auto;}
+main{max-width:960px;margin:auto;padding:var(--space-16);display:grid;gap:var(--space-24);}
+.question{display:grid;gap:var(--space-16);animation:fade .25s ease;}
+.options{display:grid;gap:var(--space-12);}
+.option{display:flex;align-items:flex-start;gap:var(--space-12);padding:var(--space-12);border:1px solid var(--border);border-radius:12px;background:var(--card);cursor:pointer;}
+.option:hover,.option:focus-within{border-color:var(--accent);}
+.option.selected{border-color:var(--accent);background:rgba(106,160,255,.1);}
+.option input{margin-top:4px;}
+.code-block{background:#1b243a;border:1px solid var(--border);border-radius:12px;padding:var(--space-16);overflow:auto;font-family:monospace;white-space:pre-wrap;}
+footer{position:fixed;bottom:0;left:0;right:0;background:var(--card);padding:var(--space-12);display:flex;gap:var(--space-12);justify-content:flex-end;border-top:1px solid var(--border);}
+/* drawer */
+.drawer{position:fixed;top:0;left:0;height:100%;width:320px;background:var(--card);transform:translateX(-100%);transition:transform .25s ease-in-out;box-shadow:2px 0 8px rgba(0,0,0,.4);display:flex;flex-direction:column;padding:var(--space-16);gap:var(--space-12);}
+.drawer.open{transform:none;}
+.drawer-backdrop{position:fixed;inset:0;background:rgba(0,0,0,.5);opacity:0;pointer-events:none;transition:opacity .25s ease-in-out;}
+.drawer-backdrop.show{opacity:1;pointer-events:auto;}
+.qnav{display:grid;grid-template-columns:repeat(auto-fill,40px);gap:var(--space-8);}
+.qchip{width:40px;height:40px;border-radius:8px;border:1px solid var(--border);display:flex;align-items:center;justify-content:center;cursor:pointer;background:var(--card);color:var(--text);}
+.qchip.answered{background:var(--accent);color:#fff;}
+.qchip.flagged{border-style:dashed;}
+@keyframes fade{from{opacity:0;transform:translateY(10px);}to{opacity:1;transform:translateY(0);}}
+</style>
+</head>
+<body>
+<header>
+  <button id="menu" aria-label="Open navigation" aria-expanded="false">☰</button>
+  <h1 id="title">Sample Quiz</h1>
+  <div id="timer" role="timer">00:00</div>
+</header>
+
+<aside id="drawer" class="drawer" role="dialog" aria-modal="true" aria-labelledby="drawer-title">
+  <div style="display:flex;justify-content:space-between;align-items:center;">
+    <h2 id="drawer-title">Questions</h2>
+    <button id="close">✕</button>
+  </div>
+  <div id="qnav" class="qnav"></div>
+</aside>
+<div id="backdrop" class="drawer-backdrop"></div>
+
+<main>
+  <section id="question" class="question">
+    <div class="stem">What does the following code output?</div>
+    <pre class="code-block"><code class="language-js">console.log('Hello world');
+</code></pre>
+    <div class="options">
+      <label class="option"><input type="radio" name="opt" value="a"><span>Hello world</span></label>
+      <label class="option"><input type="radio" name="opt" value="b"><span>Goodbye</span></label>
+      <label class="option"><input type="radio" name="opt" value="c"><span>Error</span></label>
+    </div>
+  </section>
+</main>
+
+<footer>
+  <button id="back">Back</button>
+  <button id="save">Save &amp; Next</button>
+  <button id="flag">Mark for review</button>
+  <button id="submit">Submit</button>
+</footer>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script>hljs.highlightAll();</script>
+<script>
+const state={index:0,answers:{},flagged:new Set()};
+const drawer=document.getElementById('drawer');
+const backdrop=document.getElementById('backdrop');
+const menu=document.getElementById('menu');
+const closeBtn=document.getElementById('close');
+menu.addEventListener('click',openDrawer);
+closeBtn.addEventListener('click',closeDrawer);
+backdrop.addEventListener('click',closeDrawer);
+document.addEventListener('keydown',e=>{if(e.key==='Escape'&&drawer.classList.contains('open'))closeDrawer();});
+function openDrawer(){drawer.classList.add('open');backdrop.classList.add('show');menu.setAttribute('aria-expanded','true');trap();}
+function closeDrawer(){drawer.classList.remove('open');backdrop.classList.remove('show');menu.setAttribute('aria-expanded','false');release();}
+/* focus trap */
+let focusable;function trap(){focusable=drawer.querySelectorAll('button,.qchip');focusable[0]?.focus();document.addEventListener('keydown',trapTab);}
+function release(){document.removeEventListener('keydown',trapTab);}
+function trapTab(e){if(e.key!=='Tab')return;const first=focusable[0];const last=focusable[focusable.length-1];if(e.shiftKey&&document.activeElement===first){e.preventDefault();last.focus();}else if(!e.shiftKey&&document.activeElement===last){e.preventDefault();first.focus();}}
+/* nav chips */
+const qnav=document.getElementById('qnav');
+for(let i=1;i<=5;i++){const b=document.createElement('button');b.className='qchip';b.textContent=i;b.addEventListener('click',()=>{state.index=i-1;});qnav.appendChild(b);}
+/* option selection */
+document.querySelectorAll('.option input').forEach(inp=>{
+  inp.addEventListener('change',e=>{
+    state.answers[state.index]=e.target.value;
+    document.querySelectorAll('.option').forEach(o=>o.classList.toggle('selected',o.contains(e.target)));
+  });
+});
+document.getElementById('flag').addEventListener('click',()=>{
+  if(state.flagged.has(state.index)){state.flagged.delete(state.index);}else{state.flagged.add(state.index);}updateChips();});
+function updateChips(){qnav.childNodes.forEach((b,i)=>{b.classList.toggle('answered',state.answers[i]!=null);b.classList.toggle('flagged',state.flagged.has(i));});}
+</script>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -212,10 +212,10 @@ img.preview{max-height:72px; display:block; margin-top:8px; border-radius:10px; 
 
 .opt textarea.code{width:100%;min-height:90px;margin-top:8px;}
 .opt select.lang{margin-top:8px;}
-.code-carousel{display:flex;align-items:center;gap:8px;}
-.code-carousel .view{overflow:hidden;flex:1;}
+.code-carousel{display:flex;align-items:center;justify-content:center;gap:8px;margin:0 auto;}
+.code-carousel .view{overflow:hidden;flex:1 1 auto;}
 .code-carousel .track{display:flex;transition:transform .3s;}
 .code-carousel .slide{flex:0 0 100%;}
-.code-carousel .option-card{flex-direction:column;align-items:flex-start;}
+.code-carousel .option-card{flex-direction:column;align-items:center;}
 .code-carousel pre{margin:0;width:100%;overflow:auto;}
 .code-carousel button{background:var(--accent);color:#fff;border:none;padding:6px 10px;}

--- a/public/styles.css
+++ b/public/styles.css
@@ -209,3 +209,13 @@ img.preview{max-height:72px; display:block; margin-top:8px; border-radius:10px; 
 @keyframes shimmer{0%{background-position:100% 0}100%{background-position:-100% 0}}
 .fade{animation:fade .3s;}
 @keyframes fade{from{opacity:0; transform:translateX(10px);}to{opacity:1; transform:none;}}
+
+.opt textarea.code{width:100%;min-height:90px;margin-top:8px;}
+.opt select.lang{margin-top:8px;}
+.code-carousel{display:flex;align-items:center;gap:8px;}
+.code-carousel .view{overflow:hidden;flex:1;}
+.code-carousel .track{display:flex;transition:transform .3s;}
+.code-carousel .slide{flex:0 0 100%;}
+.code-carousel .option-card{flex-direction:column;align-items:flex-start;}
+.code-carousel pre{margin:0;width:100%;overflow:auto;}
+.code-carousel button{background:var(--accent);color:#fff;border:none;padding:6px 10px;}

--- a/public/styles.css
+++ b/public/styles.css
@@ -168,7 +168,7 @@ img.preview{max-height:72px; display:block; margin-top:8px; border-radius:10px; 
 .timer.warning{background:var(--warning); color:#000;}
 .timer.danger{background:var(--danger); color:#fff;}
 .layout{display:flex; align-items:flex-start;}
-.sidebar{width:280px; position:sticky; top:70px; align-self:flex-start; padding:16px; display:flex; flex-direction:column; gap:12px;}
+.sidebar{width:280px; position:absolute; top:90px; align-self:flex-start; padding:16px; display:none; flex-direction:column; gap:12px;}
 .sidebar-hidden .sidebar{display:none;}
 .toggle-sidebar{margin-right:8px;}
 .qnums{display:flex; flex-wrap:wrap; gap:8px;}
@@ -214,8 +214,8 @@ img.preview{max-height:72px; display:block; margin-top:8px; border-radius:10px; 
 .opt select.lang{margin-top:8px;}
 
 /* code option master-detail layout */
-.code-layout{display:grid;grid-template-columns:280px 1fr;gap:16px;}
-.option-list{display:flex;flex-direction:column;gap:8px;max-height:60vh;overflow:auto;}
+.code-layout{display:grid;grid-template-columns:14% 1fr;gap:16px;}
+.option-list{display:flex;flex-direction:column;gap:8px;max-height:60vh;overflow:hidden;}
 .option-preview{display:flex;flex-direction:column;gap:4px;padding:8px;border:1px solid var(--border);border-radius:12px;background:var(--card);cursor:pointer;min-height:44px;}
 .option-preview:hover{border-color:var(--accent);}
 .option-preview input{margin:0;}

--- a/public/styles.css
+++ b/public/styles.css
@@ -212,10 +212,22 @@ img.preview{max-height:72px; display:block; margin-top:8px; border-radius:10px; 
 
 .opt textarea.code{width:100%;min-height:90px;margin-top:8px;}
 .opt select.lang{margin-top:8px;}
-.code-carousel{display:flex;align-items:center;justify-content:center;gap:8px;margin:0 auto;}
-.code-carousel .view{overflow:hidden;flex:1 1 auto;}
-.code-carousel .track{display:flex;transition:transform .3s;}
-.code-carousel .slide{flex:0 0 100%;}
-.code-carousel .option-card{flex-direction:column;align-items:center;}
-.code-carousel pre{margin:0;width:100%;overflow:auto;}
-.code-carousel button{background:var(--accent);color:#fff;border:none;padding:6px 10px;}
+
+/* code option master-detail layout */
+.code-layout{display:grid;grid-template-columns:280px 1fr;gap:16px;}
+.option-list{display:flex;flex-direction:column;gap:8px;max-height:60vh;overflow:auto;}
+.option-preview{display:flex;flex-direction:column;gap:4px;padding:8px;border:1px solid var(--border);border-radius:12px;background:var(--card);cursor:pointer;min-height:44px;}
+.option-preview:hover{border-color:var(--accent);}
+.option-preview input{margin:0;}
+.option-preview:focus{outline:3px solid var(--accent);outline-offset:2px;}
+.option-preview .code-preview{font-family:monospace;font-size:13px;background:var(--bg);padding:4px;border-radius:6px;}
+.code-preview{display:-webkit-box;-webkit-line-clamp:4;-webkit-box-orient:vertical;overflow:hidden;}
+.option-preview.expanded .code-preview{-webkit-line-clamp:unset;}
+.option-preview .chevron{margin-left:auto;align-self:flex-end;}
+.code-viewer{position:relative;max-height:60vh;overflow:auto;background:#0f1422;border:1px solid #1b243a;border-radius:12px;padding:8px;}
+.code-viewer pre{white-space:pre;overflow-wrap:normal;word-break:normal;margin:0;}
+.code-viewer.wrap pre{white-space:pre-wrap;overflow-wrap:anywhere;}
+.code-controls{position:absolute;top:4px;right:8px;display:flex;gap:8px;}
+.code-controls button{background:var(--accent);color:#fff;border:none;padding:4px 6px;border-radius:6px;min-height:44px;}
+
+.typed-answer{width:100%;overflow:auto;resize:vertical;max-height:60vh;}

--- a/public/take.html
+++ b/public/take.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="styles.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/plugins/line-numbers.min.css" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/plugins/line-numbers.min.js"></script>
 </head>
 <body>
   <div id="settings-modal" class="modal">

--- a/public/take.html
+++ b/public/take.html
@@ -6,6 +6,8 @@
   <title>Aplicar Prova</title>
   <script src="theme-init.js"></script>
   <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 </head>
 <body>
   <div id="settings-modal" class="modal">

--- a/public/take.js
+++ b/public/take.js
@@ -204,9 +204,9 @@ function renderQuestion(){
         const ans=state.answers[q._id];
         if(Array.isArray(ans)?ans.includes(idx):ans===idx) inp.checked=true;
         label.appendChild(inp);
-        const preview=document.createElement('pre'); preview.className='code-preview'; preview.textContent=(o.code||'').split('\n').slice(0,5).join('\n');
-        label.appendChild(preview);
-        const chev=document.createElement('span'); chev.className='chevron'; chev.textContent='▸'; label.appendChild(chev);
+        //const preview=document.createElement('pre'); preview.className='code-preview'; preview.textContent=(o.code||'').split('\n').slice(0,5).join('\n');
+        //label.appendChild(preview);
+        //const chev=document.createElement('span'); chev.className='chevron'; chev.textContent='▸'; label.appendChild(chev);
         label.addEventListener('click', e=>{ if(e.target!==inp){ inp.checked=q.type==='multiple'? !inp.checked : true; inp.dispatchEvent(new Event('change',{bubbles:true})); } showCode(idx); if(window.innerWidth<768) viewer.requestFullscreen(); });
         label.addEventListener('keydown', e=>{ if(e.key===' '){ e.preventDefault(); label.classList.toggle('expanded'); } });
         inp.addEventListener('change', ()=>{ showCode(idx); });

--- a/public/take.js
+++ b/public/take.js
@@ -170,20 +170,56 @@ function renderQuestion(){
     const fs = document.createElement('fieldset');
     const legend = document.createElement('legend'); legend.textContent = q.text || '';
     fs.appendChild(legend);
-    q.options.forEach((o, idx)=>{
-      const label = document.createElement('label'); label.className='option-card';
-      const inp = document.createElement('input');
-      inp.type = q.type==='multiple' ? 'checkbox' : 'radio';
-      inp.name='opt'; inp.value=idx;
-      const ans = state.answers[q._id];
-      if(Array.isArray(ans) ? ans.includes(idx) : ans===idx) inp.checked = true;
-      label.appendChild(inp);
-      const span = document.createElement('span'); span.textContent = o.text || '';
-      label.appendChild(span);
-      fs.appendChild(label);
-    });
+    const hasCode = q.options.some(o=>o.code);
+    if(hasCode){
+      const wrapper=document.createElement('div'); wrapper.className='code-carousel';
+      const prev=document.createElement('button'); prev.type='button'; prev.textContent='◀';
+      const next=document.createElement('button'); next.type='button'; next.textContent='▶';
+      const view=document.createElement('div'); view.className='view';
+      const track=document.createElement('div'); track.className='track';
+      q.options.forEach((o,idx)=>{
+        const slide=document.createElement('div'); slide.className='slide';
+        const label=document.createElement('label'); label.className='option-card';
+        const inp=document.createElement('input');
+        inp.type=q.type==='multiple'?'checkbox':'radio';
+        inp.name='opt'; inp.value=idx;
+        const ans=state.answers[q._id];
+        if(Array.isArray(ans)?ans.includes(idx):ans===idx) inp.checked=true;
+        label.appendChild(inp);
+        const pre=document.createElement('pre');
+        const code=document.createElement('code');
+        code.textContent=o.code||'';
+        if(o.language) code.classList.add('language-'+o.language);
+        pre.appendChild(code);
+        label.appendChild(pre);
+        slide.appendChild(label);
+        track.appendChild(slide);
+      });
+      view.appendChild(track);
+      wrapper.append(prev, view, next);
+      fs.appendChild(wrapper);
+      let cIndex=0;
+      function update(){ track.style.transform=`translateX(-${cIndex*100}%)`; }
+      prev.onclick=()=>{ cIndex=(cIndex-1+q.options.length)%q.options.length; update(); };
+      next.onclick=()=>{ cIndex=(cIndex+1)%q.options.length; update(); };
+      update();
+    } else {
+      q.options.forEach((o, idx)=>{
+        const label=document.createElement('label'); label.className='option-card';
+        const inp=document.createElement('input');
+        inp.type=q.type==='multiple'?'checkbox':'radio';
+        inp.name='opt'; inp.value=idx;
+        const ans=state.answers[q._id];
+        if(Array.isArray(ans)?ans.includes(idx):ans===idx) inp.checked=true;
+        label.appendChild(inp);
+        const span=document.createElement('span'); span.textContent=o.text||'';
+        label.appendChild(span);
+        fs.appendChild(label);
+      });
+    }
     els.form.appendChild(fs);
     els.form.classList.add('fade');
+    if(window.hljs) hljs.highlightAll();
     if(state.mode==='practice' && shouldCheck(q)) showCorrectness(q);
     updateSidebar(); updateProgress();
     setTimeout(()=>els.form.classList.remove('fade'),300);

--- a/server.js
+++ b/server.js
@@ -197,6 +197,8 @@ app.post('/api/questions', async (req, res) => {
       options: parsedOptions.map(o => ({
         text: o.text || '',
         imagePath: o.imageBase64 ? saveBase64Image(o.imageBase64) : (o.imagePath || ''),
+        code: o.code || '',
+        language: o.language || '',
         isCorrect: !!o.isCorrect
       }))
     });
@@ -244,6 +246,8 @@ app.put('/api/questions/:id', async (req, res) => {
         options: parsedOptions.map(o => ({
           text: o.text || '',
           imagePath: o.imageBase64 ? saveBase64Image(o.imageBase64) : (o.imagePath || ''),
+          code: o.code || '',
+          language: o.language || '',
           isCorrect: !!o.isCorrect
         }))
       },
@@ -357,7 +361,7 @@ app.post('/api/import/pdf', upload.single('file'), async (req, res) => {
       examId: exam._id,
       text: q.text,
       type: q.answers.length > 1 ? 'multiple' : 'single',
-      options: q.options.map((opt, idx) => ({ text: opt, isCorrect: q.answers.includes(idx) }))
+      options: q.options.map((opt, idx) => ({ text: opt, code: '', language: '', isCorrect: q.answers.includes(idx) }))
     }));
     await Question.insertMany(docs);
     res.json({ imported: docs.length, examId: exam._id });
@@ -391,6 +395,8 @@ app.post('/api/import', async (req, res) => {
             ? q.options.map(o => ({
                 text: o.text || '',
                 imagePath: o.imageBase64 ? saveBase64Image(o.imageBase64) : (o.imagePath || ''),
+                code: o.code || '',
+                language: o.language || '',
                 isCorrect: !!o.isCorrect
               }))
             : []


### PR DESCRIPTION
## Summary
- allow question options to store code snippets and language
- render code options in carousel with syntax highlight on exam page
- add editor fields and styling for code-based options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0f464d730832da18e6cc09ebaa197