### PR TITLE
feat: add ChatGPT-powered question generation and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,18 @@ A página `questions.html` possui uma seção **Substituir termos** para facilit
 
 ---
 
+## 🤖 Integração com ChatGPT
+
+O backend possui rotas que utilizam a API do OpenAI para gerar e validar questões automaticamente:
+
+- `POST /api/gpt/generate` – gera novas questões para uma prova a partir de um `prompt` informado.
+- `POST /api/gpt/verify` – verifica se as respostas cadastradas estão corretas segundo o ChatGPT.
+- `POST /api/gpt/explain` – cria uma explicação para a questão caso ainda não exista.
+
+Para usar as rotas é necessário definir a variável de ambiente `OPENAI_API_KEY` com um token válido da API.
+
+---
+
 ## 📝 Variáveis de ambiente
 
 Crie um arquivo `.env` na raiz com:

--- a/models/Question.js
+++ b/models/Question.js
@@ -15,7 +15,8 @@ const QuestionSchema = new mongoose.Schema({
   topic: { type: String, default: '' },
   status: { type: String, enum: ['draft','published'], default: 'draft' },
   deleted: { type: Boolean, default: false },
-  options: { type: [OptionSchema], default: [] }
+  options: { type: [OptionSchema], default: [] },
+  explanation: { type: String, default: '' }
 }, { timestamps: true });
 
 module.exports = mongoose.model('Question', QuestionSchema);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "mongoose": "^8.4.1",
     "multer": "^1.4.5-lts.1",
     "cors": "^2.8.5",
-    "pdf-parse": "^1.1.1"
+    "pdf-parse": "^1.1.1",
+    "openai": "^4.52.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.2"


### PR DESCRIPTION
## Summary
- add ChatGPT client and routes to generate, verify and explain exam questions
- store explanations on questions with new model field
- document ChatGPT endpoints and env var usage

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/openai)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a25f6b3708832da30a8aa74da323f3