### PR TITLE
feat: support code language in JSON imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ O retorno contém a quantidade de questões importadas e o `examId` utilizado.
 
 Também existe uma interface web em `/import.html`, acessível pelo menu **Importar**, para realizar a importação via PDF ou JSON pelo navegador.
 
+Ao usar JSON, cada questão pode incluir os campos `code` e `language` para especificar um trecho de código e sua linguagem de programação.
+
 ## 🔄 Substituição de termos nos enunciados
 
 Permite buscar um termo em todos os enunciados e substituí-lo em massa. É possível visualizar previamente quais questões serão afetadas e, após confirmação, aplicar as alterações.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,32 @@ Também existe uma interface web em `/import.html`, acessível pelo menu **Impor
 
 Ao usar JSON, cada questão pode incluir os campos `code` e `language` para especificar um trecho de código e sua linguagem de programação.
 
+Exemplo de arquivo JSON:
+
+```json
+{
+  "exams": [
+    {
+      "title": "Exame de Exemplo",
+      "questions": [
+        {
+          "text": "O que o seguinte código imprime?",
+          "code": "console.log('Hello');",
+          "language": "javascript",
+          "type": "single",
+          "options": [
+            { "text": "Hello", "isCorrect": true },
+            { "text": "World", "isCorrect": false }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Um exemplo mais completo pode ser encontrado em `public/sample-import.json`.
+
 ## 🔄 Substituição de termos nos enunciados
 
 Permite buscar um termo em todos os enunciados e substituí-lo em massa. É possível visualizar previamente quais questões serão afetadas e, após confirmação, aplicar as alterações.

--- a/models/Question.js
+++ b/models/Question.js
@@ -11,6 +11,8 @@ const QuestionSchema = new mongoose.Schema({
   examId: { type: mongoose.Schema.Types.ObjectId, ref: 'Exam', required: true },
   text: { type: String, default: '' },
   imagePath: { type: String, default: '' },
+  code: { type: String, default: '' },
+  language: { type: String, default: '' },
   type: { type: String, enum: ['single','multiple'], default: 'single' },
   topic: { type: String, default: '' },
   status: { type: String, enum: ['draft','published'], default: 'draft' },

--- a/public/sample-import.json
+++ b/public/sample-import.json
@@ -35,6 +35,16 @@
               "imageBase64": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/w8AAwMB/Ur8/oUAAAAASUVORK5CYII="
             }
           ]
+        },
+        {
+          "text": "O que o seguinte código imprime?",
+          "code": "console.log('Hello');",
+          "language": "javascript",
+          "type": "single",
+          "options": [
+            { "text": "Hello", "isCorrect": true },
+            { "text": "World", "isCorrect": false }
+          ]
         }
       ]
     }

--- a/server.js
+++ b/server.js
@@ -182,7 +182,7 @@ app.delete('/api/exams/:id', async (req, res) => {
 // Questions
 app.post('/api/questions', async (req, res) => {
   try {
-    const { examId, text, type, options, imagePath, imageBase64, topic, status } = req.body;
+    const { examId, text, type, options, imagePath, imageBase64, topic, status, code, language } = req.body;
     if (!examId) return res.status(400).json({ error: 'examId is required' });
     let qImagePath = imagePath || '';
     if (imageBase64) qImagePath = saveBase64Image(imageBase64);
@@ -191,6 +191,8 @@ app.post('/api/questions', async (req, res) => {
       examId,
       text,
       imagePath: qImagePath,
+      code: code || '',
+      language: language || '',
       type: ['single','multiple'].includes(type) ? type : 'single',
       topic: topic || '',
       status: ['draft','published'].includes(status) ? status : 'draft',
@@ -231,7 +233,7 @@ app.get('/api/questions', async (req, res) => {
 
 app.put('/api/questions/:id', async (req, res) => {
   try {
-    const { text, type, options, imagePath, imageBase64, topic, status } = req.body;
+    const { text, type, options, imagePath, imageBase64, topic, status, code, language } = req.body;
     let qImagePath = imagePath || '';
     if (imageBase64) qImagePath = saveBase64Image(imageBase64);
     const parsedOptions = Array.isArray(options) ? options : [];
@@ -240,6 +242,8 @@ app.put('/api/questions/:id', async (req, res) => {
       {
         text,
         imagePath: qImagePath,
+        code: code || '',
+        language: language || '',
         type: ['single','multiple'].includes(type) ? type : 'single',
         topic: topic || '',
         status: ['draft','published'].includes(status) ? status : 'draft',
@@ -390,6 +394,8 @@ app.post('/api/import', async (req, res) => {
           examId: exam._id,
           text: q.text || '',
           imagePath: q.imageBase64 ? saveBase64Image(q.imageBase64) : (q.imagePath || ''),
+          code: q.code || '',
+          language: q.language || '',
           type: ['single', 'multiple'].includes(q.type) ? q.type : 'single',
           options: Array.isArray(q.options)
             ? q.options.map(o => ({


### PR DESCRIPTION
## Summary
- allow questions to store code snippets and languages
- handle `code` and `language` fields when importing exams via JSON
- update sample import and docs with language example

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3d1012a80832d8983738150045892