### PR TITLE
fix: avoid overwriting questions when saving new ones

### DIFF
--- a/public/questions.js
+++ b/public/questions.js
@@ -165,6 +165,7 @@ function gatherForm(){
 
 function resetForm(){
   $('#qForm')[0].reset();
+  $('#qid').val('');
   $('#qimg').removeData('imagePath');
   $('#qimgPreview').hide().attr('src','');
   $('#opts').empty();


### PR DESCRIPTION
## Summary
- Clear hidden question ID when resetting the form so new questions use POST

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3d33b4c28832d97d28404efccac8d